### PR TITLE
Fix: Register host extension for isolated worker model

### DIFF
--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsQueueTriggerAttribute.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsQueueTriggerAttribute.cs
@@ -6,16 +6,18 @@ using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 /// <summary>
 /// Attribute used to mark a function that should be triggered by Amazon SQS queue messages.
 /// Compatible with Azure Functions isolated worker model.
+/// The class name must match the in-process attribute (SqsQueueTriggerAttribute) so the
+/// binding type "sqsQueueTrigger" matches what the host-side WebJobs extension registers.
 /// </summary>
 [InputConverter(typeof(SqsMessageConverter))]
 [ConverterFallbackBehavior(ConverterFallbackBehavior.Default)]
-public sealed class SqsTriggerAttribute : TriggerBindingAttribute
+public sealed class SqsQueueTriggerAttribute : TriggerBindingAttribute
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="SqsTriggerAttribute"/> class.
+    /// Initializes a new instance of the <see cref="SqsQueueTriggerAttribute"/> class.
     /// </summary>
     /// <param name="queueUrl">The URL of the SQS queue to monitor.</param>
-    public SqsTriggerAttribute(string queueUrl)
+    public SqsQueueTriggerAttribute(string queueUrl)
     {
         QueueUrl = queueUrl ?? throw new ArgumentNullException(nameof(queueUrl));
     }

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/WorkerExtensionStartup.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/WorkerExtensionStartup.cs
@@ -1,0 +1,3 @@
+using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+[assembly: ExtensionInformation("Extensions.Azure.WebJobs.SQS", "1.0.0")]

--- a/dotnet/test/Extensions.SQS.Test.Isolated/Functions/SqsTriggerFunction.cs
+++ b/dotnet/test/Extensions.SQS.Test.Isolated/Functions/SqsTriggerFunction.cs
@@ -21,7 +21,7 @@ public class SqsTriggerFunction
     /// </summary>
     [Function(nameof(ProcessSqsMessage))]
     public void ProcessSqsMessage(
-        [SqsTrigger("%SQS_QUEUE_URL%")] Message message)
+        [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message)
     {
         _logger.LogInformation("=== SQS Message Received ===");
         _logger.LogInformation("Message ID: {MessageId}", message.MessageId);
@@ -42,7 +42,7 @@ public class SqsTriggerFunction
     /// </summary>
     [Function(nameof(ProcessSqsMessageAsync))]
     public async Task ProcessSqsMessageAsync(
-        [SqsTrigger("%SQS_QUEUE_URL%")] Message message)
+        [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message)
     {
         _logger.LogInformation("Processing message asynchronously: {MessageId}", message.MessageId);
 


### PR DESCRIPTION
## Summary
Fixes two issues that prevented the isolated worker model from registering the SQS trigger binding:

1. **Missing host extension registration** — Added `[assembly: ExtensionInformation]` attribute so the Worker SDK automatically discovers and loads the WebJobs host extension during build
2. **Binding type name mismatch** — Renamed `SqsTriggerAttribute` to `SqsQueueTriggerAttribute` to match the host-side attribute name. The binding type is derived from the class name (`sqsTrigger` vs `sqsQueueTrigger`), so the mismatch caused the host to not recognize the binding

Closes #75

> **Note:** The worker extension has no unit test coverage, which is how these bugs shipped undetected. Tracked in #77.

## Test plan
- [x] `dotnet build` succeeds for isolated and in-process test projects
- [x] `extensions.json` includes `SqsExtensionStartup` registration
- [x] `functions.metadata` emits `sqsQueueTrigger` binding type (matching host)
- [x] `func start` loads all 5 functions (including SQS triggers) without binding errors
- [x] Existing unit tests unaffected