### PR TITLE
Fix ParameterBindingData cast error for isolated worker model

### DIFF
--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/AssemblyInfo.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Extensions.SQS.UnitTests")]

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/Azure.Functions.Worker.Extensions.SQS.csproj
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/Azure.Functions.Worker.Extensions.SQS.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>Github</RepositoryType>
     <AssemblyName>Azure.Functions.Worker.Extensions.SQS</AssemblyName>
     <RootNamespace>Azure.Functions.Worker.Extensions.SQS</RootNamespace>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Azure Functions Worker bindings extension SQS AWS Amazon isolated out-of-process</PackageTags>
     <PackageProjectUrl>https://github.com/laveeshb/azure-functions-sqs-extension</PackageProjectUrl>

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsMessageConverter.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsMessageConverter.cs
@@ -4,11 +4,12 @@ using System.Text.Json;
 using Amazon.SQS.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Core;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 /// <summary>
 /// Converter to bind SQS message data to strongly typed parameters in isolated worker functions.
-/// Converts ModelBindingData from the Azure Functions host to SQS message types.
+/// Converts ParameterBindingData from the Azure Functions host to SQS message types.
 /// </summary>
 [SupportsDeferredBinding]
 [SupportedTargetType(typeof(Message))]
@@ -21,27 +22,28 @@ internal sealed class SqsMessageConverter : IInputConverter
     {
         try
         {
-            // For now, handle string sources from trigger data
-            // The host will serialize SQS messages as JSON strings
-            if (context.Source is string json && !string.IsNullOrEmpty(json))
+            var json = ExtractJson(context.Source);
+            if (string.IsNullOrEmpty(json))
             {
-                if (context.TargetType == typeof(Message))
-                {
-                    var message = JsonSerializer.Deserialize<SqsMessageData>(json);
-                    if (message == null)
-                    {
-                        throw new InvalidOperationException("Failed to deserialize SQS message data.");
-                    }
+                return new ValueTask<ConversionResult>(ConversionResult.Unhandled());
+            }
 
-                    var result = ConvertToSqsMessage(message);
-                    return new ValueTask<ConversionResult>(ConversionResult.Success(result));
+            if (context.TargetType == typeof(Message))
+            {
+                var message = JsonSerializer.Deserialize<SqsMessageData>(json);
+                if (message == null)
+                {
+                    throw new InvalidOperationException("Failed to deserialize SQS message data.");
                 }
 
-                if (context.TargetType == typeof(string))
-                {
-                    var message = JsonSerializer.Deserialize<SqsMessageData>(json);
-                    return new ValueTask<ConversionResult>(ConversionResult.Success(message?.Body ?? json));
-                }
+                var result = ConvertToSqsMessage(message);
+                return new ValueTask<ConversionResult>(ConversionResult.Success(result));
+            }
+
+            if (context.TargetType == typeof(string))
+            {
+                var message = JsonSerializer.Deserialize<SqsMessageData>(json);
+                return new ValueTask<ConversionResult>(ConversionResult.Success(message?.Body ?? json));
             }
 
             return new ValueTask<ConversionResult>(ConversionResult.Unhandled());
@@ -50,6 +52,17 @@ internal sealed class SqsMessageConverter : IInputConverter
         {
             return new ValueTask<ConversionResult>(ConversionResult.Failed(ex));
         }
+    }
+
+    private static string? ExtractJson(object? source)
+    {
+        return source switch
+        {
+            ModelBindingData bindingData when string.Equals(bindingData.ContentType, ExpectedContentType, StringComparison.OrdinalIgnoreCase)
+                => bindingData.Content?.ToString(),
+            string str => str,
+            _ => null
+        };
     }
 
     private static Message ConvertToSqsMessage(SqsMessageData content)
@@ -83,8 +96,8 @@ internal sealed class SqsMessageConverter : IInputConverter
             {
                 DataType = kvp.Value.DataType,
                 StringValue = kvp.Value.StringValue,
-                BinaryValue = kvp.Value.BinaryValue != null 
-                    ? new MemoryStream(kvp.Value.BinaryValue) 
+                BinaryValue = kvp.Value.BinaryValue != null
+                    ? new MemoryStream(kvp.Value.BinaryValue)
                     : null
             };
         }

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/WorkerExtensionStartup.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/WorkerExtensionStartup.cs
@@ -1,3 +1,3 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Extensions.Azure.WebJobs.SQS", "1.0.0")]
+[assembly: ExtensionInformation("Extensions.Azure.WebJobs.SQS", "1.1.0")]

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/AssemblyInfo.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Extensions.SQS.UnitTests")]

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>Github</RepositoryType>
     <AssemblyName>Azure.WebJobs.Extensions.SQS</AssemblyName>
     <RootNamespace>Azure.WebJobs.Extensions.SQS</RootNamespace>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Azure Functions WebJobs bindings extension SQS AWS Amazon in-process</PackageTags>
     <PackageProjectUrl>https://github.com/laveeshb/azure-functions-sqs-extension</PackageProjectUrl>

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueMessageValueProvider.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueMessageValueProvider.cs
@@ -2,6 +2,7 @@
 namespace Azure.WebJobs.Extensions.SQS;
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -11,16 +12,10 @@ using Microsoft.Azure.WebJobs.Host.Bindings;
 
 public class SqsQueueMessageValueProvider : IValueProvider
 {
+    internal const string BindingDataSource = "AWSSQS";
+    internal const string BindingDataVersion = "1.0";
+    internal const string JsonContentType = "application/json";
     private const string IsolatedWorkerRuntime = "dotnet-isolated";
-    private const string BindingDataSource = "AWSSQS";
-    private const string BindingDataVersion = "1.0";
-    private const string JsonContentType = "application/json";
-
-    private static readonly bool IsIsolatedWorker =
-        string.Equals(
-            Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME"),
-            IsolatedWorkerRuntime,
-            StringComparison.OrdinalIgnoreCase);
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -28,17 +23,24 @@ public class SqsQueueMessageValueProvider : IValueProvider
     };
 
     private readonly object _value;
+    private readonly bool _isIsolatedWorker;
 
-    public Type Type => IsIsolatedWorker ? typeof(ParameterBindingData) : typeof(Message);
+    public Type Type => _isIsolatedWorker ? typeof(ParameterBindingData) : typeof(Message);
 
     public SqsQueueMessageValueProvider(object value)
+        : this(value, IsRunningInIsolatedWorker())
+    {
+    }
+
+    internal SqsQueueMessageValueProvider(object value, bool isIsolatedWorker)
     {
         _value = value ?? throw new ArgumentNullException(nameof(value));
+        _isIsolatedWorker = isIsolatedWorker;
     }
 
     public Task<object> GetValueAsync()
     {
-        if (IsIsolatedWorker && _value is Message message)
+        if (_isIsolatedWorker && _value is Message message)
         {
             var payload = SerializeMessage(message);
             var bindingData = new ParameterBindingData(
@@ -57,7 +59,15 @@ public class SqsQueueMessageValueProvider : IValueProvider
         return _value.ToString() ?? string.Empty;
     }
 
-    private static string SerializeMessage(Message message)
+    private static bool IsRunningInIsolatedWorker()
+    {
+        return string.Equals(
+            Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME"),
+            IsolatedWorkerRuntime,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string SerializeMessage(Message message)
     {
         var data = new SqsMessageData
         {
@@ -71,7 +81,7 @@ public class SqsQueueMessageValueProvider : IValueProvider
 
         if (message.MessageAttributes is { Count: > 0 })
         {
-            data.MessageAttributes = new();
+            data.MessageAttributes = new Dictionary<string, SqsMessageAttributeData>();
             foreach (var kvp in message.MessageAttributes)
             {
                 data.MessageAttributes[kvp.Key] = new SqsMessageAttributeData
@@ -86,18 +96,18 @@ public class SqsQueueMessageValueProvider : IValueProvider
         return JsonSerializer.Serialize(data, SerializerOptions);
     }
 
-    private sealed class SqsMessageData
+    internal sealed class SqsMessageData
     {
         public string? MessageId { get; set; }
         public string? ReceiptHandle { get; set; }
         public string? Body { get; set; }
         public string? MD5OfBody { get; set; }
-        public System.Collections.Generic.Dictionary<string, string>? Attributes { get; set; }
-        public System.Collections.Generic.Dictionary<string, SqsMessageAttributeData>? MessageAttributes { get; set; }
+        public Dictionary<string, string>? Attributes { get; set; }
+        public Dictionary<string, SqsMessageAttributeData>? MessageAttributes { get; set; }
         public string? MD5OfMessageAttributes { get; set; }
     }
 
-    private sealed class SqsMessageAttributeData
+    internal sealed class SqsMessageAttributeData
     {
         public string? DataType { get; set; }
         public string? StringValue { get; set; }

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueMessageValueProvider.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueMessageValueProvider.cs
@@ -1,16 +1,35 @@
-﻿
+
 namespace Azure.WebJobs.Extensions.SQS;
 
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 public class SqsQueueMessageValueProvider : IValueProvider
 {
+    private const string IsolatedWorkerRuntime = "dotnet-isolated";
+    private const string BindingDataSource = "AWSSQS";
+    private const string BindingDataVersion = "1.0";
+    private const string JsonContentType = "application/json";
+
+    private static readonly bool IsIsolatedWorker =
+        string.Equals(
+            Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME"),
+            IsolatedWorkerRuntime,
+            StringComparison.OrdinalIgnoreCase);
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
     private readonly object _value;
 
-    public Type Type => typeof(Message);
+    public Type Type => IsIsolatedWorker ? typeof(ParameterBindingData) : typeof(Message);
 
     public SqsQueueMessageValueProvider(object value)
     {
@@ -19,11 +38,69 @@ public class SqsQueueMessageValueProvider : IValueProvider
 
     public Task<object> GetValueAsync()
     {
+        if (IsIsolatedWorker && _value is Message message)
+        {
+            var payload = SerializeMessage(message);
+            var bindingData = new ParameterBindingData(
+                version: BindingDataVersion,
+                source: BindingDataSource,
+                content: BinaryData.FromString(payload),
+                contentType: JsonContentType);
+            return Task.FromResult<object>(bindingData);
+        }
+
         return Task.FromResult(_value);
     }
 
     public string ToInvokeString()
     {
         return _value.ToString() ?? string.Empty;
+    }
+
+    private static string SerializeMessage(Message message)
+    {
+        var data = new SqsMessageData
+        {
+            MessageId = message.MessageId,
+            ReceiptHandle = message.ReceiptHandle,
+            Body = message.Body,
+            MD5OfBody = message.MD5OfBody,
+            Attributes = message.Attributes,
+            MD5OfMessageAttributes = message.MD5OfMessageAttributes
+        };
+
+        if (message.MessageAttributes is { Count: > 0 })
+        {
+            data.MessageAttributes = new();
+            foreach (var kvp in message.MessageAttributes)
+            {
+                data.MessageAttributes[kvp.Key] = new SqsMessageAttributeData
+                {
+                    DataType = kvp.Value.DataType,
+                    StringValue = kvp.Value.StringValue,
+                    BinaryValue = kvp.Value.BinaryValue?.ToArray()
+                };
+            }
+        }
+
+        return JsonSerializer.Serialize(data, SerializerOptions);
+    }
+
+    private sealed class SqsMessageData
+    {
+        public string? MessageId { get; set; }
+        public string? ReceiptHandle { get; set; }
+        public string? Body { get; set; }
+        public string? MD5OfBody { get; set; }
+        public System.Collections.Generic.Dictionary<string, string>? Attributes { get; set; }
+        public System.Collections.Generic.Dictionary<string, SqsMessageAttributeData>? MessageAttributes { get; set; }
+        public string? MD5OfMessageAttributes { get; set; }
+    }
+
+    private sealed class SqsMessageAttributeData
+    {
+        public string? DataType { get; set; }
+        public string? StringValue { get; set; }
+        public byte[]? BinaryValue { get; set; }
     }
 }

--- a/dotnet/test/Extensions.SQS.UnitTests/Extensions.SQS.UnitTests.csproj
+++ b/dotnet/test/Extensions.SQS.UnitTests/Extensions.SQS.UnitTests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Azure.WebJobs.Extensions.SQS\Azure.WebJobs.Extensions.SQS.csproj" />
+    <ProjectReference Include="..\..\src\Azure.Functions.Worker.Extensions.SQS\Azure.Functions.Worker.Extensions.SQS.csproj" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/test/Extensions.SQS.UnitTests/IsolatedWorkerRoundTripTests.cs
+++ b/dotnet/test/Extensions.SQS.UnitTests/IsolatedWorkerRoundTripTests.cs
@@ -1,0 +1,229 @@
+namespace Extensions.SQS.UnitTests;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Amazon.SQS.Model;
+using Azure.Functions.Worker.Extensions.SQS;
+using Azure.WebJobs.Extensions.SQS;
+using FluentAssertions;
+using Microsoft.Azure.Functions.Worker.Converters;
+using Microsoft.Azure.Functions.Worker.Core;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Round-trip tests that verify the host-side serialization (SqsQueueMessageValueProvider)
+/// produces JSON that the worker-side converter (SqsMessageConverter) can deserialize back
+/// into the original Message. This guards against schema drift between the two packages,
+/// which was the root cause of the ParameterBindingData cast error that led to a broken
+/// isolated-worker path.
+/// </summary>
+public class IsolatedWorkerRoundTripTests
+{
+    [Fact]
+    public async Task IsolatedMode_ValueProviderReturnsParameterBindingData()
+    {
+        var message = CreateSampleMessage();
+        var provider = new SqsQueueMessageValueProvider(message, isIsolatedWorker: true);
+
+        provider.Type.Should().Be(typeof(Microsoft.Azure.WebJobs.ParameterBindingData));
+
+        var value = await provider.GetValueAsync();
+        value.Should().BeOfType<Microsoft.Azure.WebJobs.ParameterBindingData>();
+
+        var pbd = (Microsoft.Azure.WebJobs.ParameterBindingData)value;
+        pbd.Source.Should().Be(SqsQueueMessageValueProvider.BindingDataSource);
+        pbd.ContentType.Should().Be(SqsQueueMessageValueProvider.JsonContentType);
+        pbd.Version.Should().Be(SqsQueueMessageValueProvider.BindingDataVersion);
+        pbd.Content.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task InProcessMode_ValueProviderReturnsRawMessage()
+    {
+        var message = CreateSampleMessage();
+        var provider = new SqsQueueMessageValueProvider(message, isIsolatedWorker: false);
+
+        provider.Type.Should().Be(typeof(Message));
+
+        var value = await provider.GetValueAsync();
+        value.Should().BeSameAs(message);
+    }
+
+    [Fact]
+    public async Task RoundTrip_MessageSurvivesHostToWorkerSerialization()
+    {
+        // Arrange: create a message with a variety of fields populated
+        var original = CreateSampleMessage();
+
+        // Act: host-side serialization (what the value provider does in isolated mode)
+        var provider = new SqsQueueMessageValueProvider(original, isIsolatedWorker: true);
+        var hostValue = await provider.GetValueAsync();
+        var hostPbd = (Microsoft.Azure.WebJobs.ParameterBindingData)hostValue;
+
+        // Simulate: worker-side ModelBindingData with the same content (this is what the
+        // Functions runtime does across the gRPC boundary between host and worker)
+        var workerBindingData = CreateWorkerModelBindingData(
+            content: hostPbd.Content,
+            contentType: hostPbd.ContentType,
+            source: hostPbd.Source,
+            version: hostPbd.Version);
+
+        // Act: worker-side conversion back to Message
+        var converter = new SqsMessageConverter();
+        var context = CreateConverterContext(workerBindingData, typeof(Message));
+        var result = await converter.ConvertAsync(context);
+
+        // Assert: conversion succeeded and the message matches
+        result.Status.Should().Be(ConversionStatus.Succeeded);
+        var roundTripped = result.Value.Should().BeOfType<Message>().Subject;
+        roundTripped.MessageId.Should().Be(original.MessageId);
+        roundTripped.ReceiptHandle.Should().Be(original.ReceiptHandle);
+        roundTripped.Body.Should().Be(original.Body);
+        roundTripped.MD5OfBody.Should().Be(original.MD5OfBody);
+        roundTripped.MD5OfMessageAttributes.Should().Be(original.MD5OfMessageAttributes);
+        roundTripped.Attributes.Should().Equal(original.Attributes);
+        roundTripped.MessageAttributes.Should().HaveCount(original.MessageAttributes.Count);
+        roundTripped.MessageAttributes["Priority"].StringValue.Should().Be("High");
+        roundTripped.MessageAttributes["Priority"].DataType.Should().Be("String");
+    }
+
+    [Fact]
+    public async Task RoundTrip_MessageWithBinaryAttributeSurvives()
+    {
+        var original = new Message
+        {
+            MessageId = "bin-1",
+            Body = "hello",
+            ReceiptHandle = "r1",
+            MessageAttributes = new Dictionary<string, MessageAttributeValue>
+            {
+                ["Payload"] = new MessageAttributeValue
+                {
+                    DataType = "Binary",
+                    BinaryValue = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 })
+                }
+            }
+        };
+
+        var provider = new SqsQueueMessageValueProvider(original, isIsolatedWorker: true);
+        var pbd = (Microsoft.Azure.WebJobs.ParameterBindingData)await provider.GetValueAsync();
+
+        var workerBindingData = CreateWorkerModelBindingData(
+            content: pbd.Content,
+            contentType: pbd.ContentType,
+            source: pbd.Source,
+            version: pbd.Version);
+
+        var converter = new SqsMessageConverter();
+        var result = await converter.ConvertAsync(
+            CreateConverterContext(workerBindingData, typeof(Message)));
+
+        result.Status.Should().Be(ConversionStatus.Succeeded);
+        var roundTripped = (Message)result.Value!;
+        roundTripped.MessageAttributes["Payload"].DataType.Should().Be("Binary");
+        var binaryBytes = new byte[5];
+        var readCount = roundTripped.MessageAttributes["Payload"].BinaryValue.Read(binaryBytes, 0, 5);
+        readCount.Should().Be(5);
+        binaryBytes.Should().Equal(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task RoundTrip_MessageWithNoAttributesSurvives()
+    {
+        var original = new Message
+        {
+            MessageId = "empty-1",
+            Body = "just a body",
+            ReceiptHandle = "r2"
+        };
+
+        var provider = new SqsQueueMessageValueProvider(original, isIsolatedWorker: true);
+        var pbd = (Microsoft.Azure.WebJobs.ParameterBindingData)await provider.GetValueAsync();
+
+        var workerBindingData = CreateWorkerModelBindingData(pbd.Content, pbd.ContentType, pbd.Source, pbd.Version);
+        var converter = new SqsMessageConverter();
+        var result = await converter.ConvertAsync(CreateConverterContext(workerBindingData, typeof(Message)));
+
+        result.Status.Should().Be(ConversionStatus.Succeeded);
+        var roundTripped = (Message)result.Value!;
+        roundTripped.MessageId.Should().Be("empty-1");
+        roundTripped.Body.Should().Be("just a body");
+        roundTripped.MessageAttributes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Converter_WithStringTargetType_ReturnsBody()
+    {
+        var original = CreateSampleMessage();
+        var provider = new SqsQueueMessageValueProvider(original, isIsolatedWorker: true);
+        var pbd = (Microsoft.Azure.WebJobs.ParameterBindingData)await provider.GetValueAsync();
+
+        var workerBindingData = CreateWorkerModelBindingData(pbd.Content, pbd.ContentType, pbd.Source, pbd.Version);
+        var converter = new SqsMessageConverter();
+        var result = await converter.ConvertAsync(CreateConverterContext(workerBindingData, typeof(string)));
+
+        result.Status.Should().Be(ConversionStatus.Succeeded);
+        result.Value.Should().Be(original.Body);
+    }
+
+    [Fact]
+    public async Task Converter_WithUnsupportedContentType_ReturnsUnhandled()
+    {
+        var workerBindingData = CreateWorkerModelBindingData(
+            content: BinaryData.FromString("{}"),
+            contentType: "text/plain",
+            source: "AWSSQS",
+            version: "1.0");
+
+        var converter = new SqsMessageConverter();
+        var result = await converter.ConvertAsync(CreateConverterContext(workerBindingData, typeof(Message)));
+
+        result.Status.Should().Be(ConversionStatus.Unhandled);
+    }
+
+    private static Message CreateSampleMessage()
+    {
+        return new Message
+        {
+            MessageId = "msg-123",
+            ReceiptHandle = "receipt-abc",
+            Body = "Hello from SQS",
+            MD5OfBody = "deadbeef",
+            MD5OfMessageAttributes = "cafebabe",
+            Attributes = new Dictionary<string, string>
+            {
+                ["SenderId"] = "sender-1",
+                ["SentTimestamp"] = "1234567890"
+            },
+            MessageAttributes = new Dictionary<string, MessageAttributeValue>
+            {
+                ["Priority"] = new MessageAttributeValue
+                {
+                    DataType = "String",
+                    StringValue = "High"
+                }
+            }
+        };
+    }
+
+    private static ModelBindingData CreateWorkerModelBindingData(
+        BinaryData content, string contentType, string source, string version)
+    {
+        var mock = new Mock<ModelBindingData>();
+        mock.SetupGet(m => m.Content).Returns(content);
+        mock.SetupGet(m => m.ContentType).Returns(contentType);
+        mock.SetupGet(m => m.Source).Returns(source);
+        mock.SetupGet(m => m.Version).Returns(version);
+        return mock.Object;
+    }
+
+    private static ConverterContext CreateConverterContext(object source, System.Type targetType)
+    {
+        var mock = new Mock<ConverterContext>();
+        mock.SetupGet(c => c.Source).Returns(source);
+        mock.SetupGet(c => c.TargetType).Returns(targetType);
+        return mock.Object;
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the runtime cast error reported after #76 merged:

```
Unable to cast object of type 'Amazon.SQS.Model.Message' to type 'Microsoft.Azure.WebJobs.ParameterBindingData'
```

### Root cause
The worker extension's `SqsMessageConverter` is decorated with `[SupportsDeferredBinding]`, which tells the Functions host to send a `ParameterBindingData` wrapper across the gRPC boundary to the isolated worker process. However, the host-side `SqsQueueMessageValueProvider` was returning the raw `Amazon.SQS.Model.Message` object, causing the cast to fail inside the WebJobs runtime.

### Changes
- **Host side** (`SqsQueueMessageValueProvider`): Detects `FUNCTIONS_WORKER_RUNTIME=dotnet-isolated` and returns a `ParameterBindingData` containing JSON-serialized message content. Raw `Message` is still returned for the in-process model, preserving backward compatibility.
- **Worker side** (`SqsMessageConverter`): Now reads from `ModelBindingData` (the worker-side counterpart of `ParameterBindingData`) and deserializes the JSON payload into an `Amazon.SQS.Model.Message`.
- **Versioning**: Both packages bumped to `1.1.0` and the `ExtensionInformation` attribute updated to match. The worker package pulls the matching host package transitively, so consumers only see one installed package.
- **Tests**: Added `IsolatedWorkerRoundTripTests` with 7 new tests covering:
  - Isolated-mode vs in-process-mode behavior for the value provider
  - Full round-trip: `Message` → host JSON → `ModelBindingData` → worker converter → `Message`
  - Edge cases: binary attributes, empty attributes, string target type, unsupported content type

  The round-trip test is the key addition — it's designed to catch schema drift between the host and worker serialization, which is the class of bug that caused this issue. Partially addresses #77.

Closes #78

## Impact on the in-process model
**None.** The isolated detection checks `FUNCTIONS_WORKER_RUNTIME=dotnet-isolated`; in-process runs with a different value, so the code path returns the raw `Message` exactly as before. All 11 pre-existing value-provider tests still pass, and the new `InProcessMode_ValueProviderReturnsRawMessage` test covers this case explicitly.

## Test plan
- [x] Both extensions build cleanly (net6.0 and net8.0)
- [x] In-process test project still builds (backward compatibility preserved)
- [x] All 11 pre-existing `SqsQueueMessageValueProvider` tests pass
- [x] All 7 new round-trip tests pass
- [x] `func start` loads the new host extension (verified locally via `1.0.1-local` pack, then rolled to `1.1.0`)
- [x] End-to-end verification with real SQS queue — pending @asadahmed1362's test (see comment below for instructions)

## Release
A new `1.1.0` release will follow once end-to-end verification is confirmed.