### PR TITLE
Set .NET 1.1.0 release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) an
 
 ## .NET
 
-### 1.1.0 — Unreleased
+### 1.1.0 — 2026-04-14
 
 #### Fixed
 - Isolated worker model now functions end-to-end. Previously, the isolated worker SQS trigger failed at startup and later at runtime due to:


### PR DESCRIPTION
Replaces `Unreleased` with the actual release date (2026-04-14) now that `1.1.0` is being published to NuGet.