### PR TITLE
Clarify WebJobs package scope in docs

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -8,12 +8,12 @@ on:
         required: true
         type: string
       publish-inprocess:
-        description: 'Publish In-Process package (Extensions.Azure.WebJobs.SQS)'
+        description: 'Publish host-side package (Extensions.Azure.WebJobs.SQS)'
         required: true
         type: boolean
         default: true
       publish-isolated:
-        description: 'Publish Isolated Worker package (Extensions.Azure.Functions.Worker.SQS)'
+        description: 'Publish worker-side package (Extensions.Azure.Functions.Worker.SQS)'
         required: true
         type: boolean
         default: true

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This repository provides Azure Functions extensions to integrate with [Amazon SQ
 
 For .NET developers, this extension provides two packages supporting both hosting models:
 
-- **[Azure.WebJobs.Extensions.SQS](./dotnet/src/Azure.WebJobs.Extensions.SQS/README.md)** - In-process hosting model
-- **[Azure.Functions.Worker.Extensions.SQS](./dotnet/src/Azure.Functions.Worker.Extensions.SQS/README.md)** - Isolated worker (out-of-process) model
+- **[Azure.WebJobs.Extensions.SQS](./dotnet/src/Azure.WebJobs.Extensions.SQS/README.md)** - Host-side extension. Install directly for the in-process model; isolated worker apps pick it up transitively.
+- **[Azure.Functions.Worker.Extensions.SQS](./dotnet/src/Azure.Functions.Worker.Extensions.SQS/README.md)** - Worker-side extension. Install for the isolated worker (out-of-process) model.
 
 **Features:**
 - ⚡ Trigger Azure Functions from SQS queue messages

--- a/dotnet/MIGRATION_GUIDE.md
+++ b/dotnet/MIGRATION_GUIDE.md
@@ -4,20 +4,22 @@ This guide helps you migrate between different versions of the Azure Functions S
 
 ## Current State (v1.0.0)
 
-The Azure Functions SQS Extension now provides **two separate packages** to support both hosting models:
+The Azure Functions SQS Extension provides **two separate packages**, following Microsoft's pattern for Azure Functions bindings:
 
-| Package | Model | Status | Azure Functions Platform Support |
-|---------|-------|--------|----------------------------------|
-| **Azure.WebJobs.Extensions.SQS** | In-process | ✅ Available | [Until Nov 10, 2026](https://aka.ms/azure-functions-retirements/in-process-model) |
-| **Azure.Functions.Worker.Extensions.SQS** | Isolated worker | ✅ Available (Recommended) | Ongoing |
+| Package | Role | Install directly for |
+|---------|------|----------------------|
+| **Azure.WebJobs.Extensions.SQS** | Host-side runtime extension | In-process hosting model |
+| **Azure.Functions.Worker.Extensions.SQS** | Worker-side attributes and converters | Isolated worker hosting model (recommended) |
 
-> ⚠️ **Important**: Microsoft Azure Functions will end support for the in-process hosting model on **November 10, 2026**. After this date, in-process functions will no longer be supported by the Azure Functions runtime. [Learn more about Microsoft's retirement timeline](https://aka.ms/azure-functions-retirements/in-process-model).
+The host-side package is also pulled in transitively by the worker-side package, since the Azure Functions host process is what actually listens to SQS regardless of hosting model.
 
-### Which Package Should I Use?
+> ⚠️ **Important**: Microsoft Azure Functions will end support for the **in-process hosting model** on **November 10, 2026**. After this date, you must have migrated your app to the isolated worker model to keep running on the Azure Functions runtime. The `Azure.WebJobs.Extensions.SQS` package itself remains supported — it continues to serve as the host-side runtime extension for isolated worker apps. [Learn more about Microsoft's retirement timeline](https://aka.ms/azure-functions-retirements/in-process-model).
 
-- **New projects**: Use `Extensions.Azure.Functions.Worker.SQS` (isolated worker model)
-- **Existing in-process apps**: Can continue using `Extensions.Azure.WebJobs.SQS` until **November 10, 2026** when Microsoft ends Azure Functions platform support for in-process model
-- **Legacy apps**: Migrate from old `AzureFunctions.Extension.SQS` package
+### Which Package Should I Install?
+
+- **New projects**: Install `Extensions.Azure.Functions.Worker.SQS` (isolated worker model — recommended)
+- **Existing in-process apps**: Install `Extensions.Azure.WebJobs.SQS` directly, but plan to migrate to the isolated worker model before **November 10, 2026**
+- **Legacy apps**: Migrate from the old `AzureFunctions.Extension.SQS` package
 
 ## Migration Scenarios
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -16,12 +16,12 @@ dotnet/
 
 ## Packages
 
-This extension provides two separate packages following Microsoft's pattern for Azure Functions:
+This extension provides two separate packages following Microsoft's pattern for Azure Functions. The WebJobs package is the host-side runtime extension (referenced transitively by the Worker package); the Worker package is the worker-side attributes and converters.
 
-| Package | Hosting Model | NuGet | Documentation |
-|---------|---------------|-------|---------------|
-| **Extensions.Azure.WebJobs.SQS** | In-process | Coming soon | [README](./src/Azure.WebJobs.Extensions.SQS/README.md) |
-| **Extensions.Azure.Functions.Worker.SQS** | Isolated worker | Coming soon | [README](./src/Azure.Functions.Worker.Extensions.SQS/README.md) |
+| Package | Role | Install directly for | NuGet | Documentation |
+|---------|------|----------------------|-------|---------------|
+| **Extensions.Azure.WebJobs.SQS** | Host-side extension | In-process model | Coming soon | [README](./src/Azure.WebJobs.Extensions.SQS/README.md) |
+| **Extensions.Azure.Functions.Worker.SQS** | Worker-side extension | Isolated worker model | Coming soon | [README](./src/Azure.Functions.Worker.Extensions.SQS/README.md) |
 
 ## Installation
 

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
@@ -10,7 +10,7 @@
     <Authors>Laveesh Bansal</Authors>
     <Company />
     <Product>Azure WebJobs SQS Extension</Product>
-    <Description>Amazon SQS extension for Azure Functions using the in-process hosting model.</Description>
+    <Description>Host-side Amazon SQS extension for the Azure Functions runtime. Referenced directly by in-process apps and transitively by the isolated worker package (Extensions.Azure.Functions.Worker.SQS), since the Functions host process listens to SQS in both hosting models.</Description>
     <RepositoryType>Github</RepositoryType>
     <AssemblyName>Azure.WebJobs.Extensions.SQS</AssemblyName>
     <RootNamespace>Azure.WebJobs.Extensions.SQS</RootNamespace>

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/README.md
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/README.md
@@ -1,10 +1,10 @@
 # Azure WebJobs SQS Extension
 
-Amazon SQS extension for Azure Functions using the **In-Process (WebJobs) hosting model**.
+Host-side Amazon SQS extension for the Azure Functions runtime. This package is referenced **directly** by apps using the in-process hosting model, and **transitively** (via the Worker SDK) by apps using the isolated worker hosting model, since the Functions host process is what actually listens to SQS in both cases.
 
 > 📦 **Note:** This package is a modernized continuation of the legacy [AzureFunctions.Extension.SQS](https://www.nuget.org/packages/AzureFunctions.Extension.SQS) package, updated for Azure Functions v4, .NET 6/8, and modern AWS SDK patterns.
 
-> ℹ️ **Recommendation:** For new projects, consider using [Extensions.Azure.Functions.Worker.SQS](https://www.nuget.org/packages/Extensions.Azure.Functions.Worker.SQS) which supports the **isolated worker model** (Microsoft's recommended approach). The in-process model will be [retired on November 10, 2026](https://aka.ms/azure-functions-retirements/in-process-model).
+> ℹ️ **Recommendation:** For new projects, install [Extensions.Azure.Functions.Worker.SQS](https://www.nuget.org/packages/Extensions.Azure.Functions.Worker.SQS) which supports the **isolated worker model** (Microsoft's recommended approach). Note: The in-process *hosting model* will be [retired on November 10, 2026](https://aka.ms/azure-functions-retirements/in-process-model); this package itself stays supported as the host-side runtime extension for isolated worker apps.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
The `Extensions.Azure.WebJobs.SQS` package is the **host-side** runtime extension, not an in-process-only package. It's required by both hosting models: in-process apps reference it directly, and isolated worker apps pull it in transitively via the Worker SDK, because the Azure Functions host process is what actually listens to SQS in both cases.

Previous docs framed it as "the in-process package" and implied its support would end with Microsoft's in-process hosting model retirement on 2026-11-10 — neither is accurate.

### Changes
- **Root README** — host-side/worker-side roles made explicit in the package list
- **dotnet/README** — packages table now shows role + which hosting model to install directly for
- **dotnet/MIGRATION_GUIDE** — restored accurate support timeline: only the in-process hosting model retires; the WebJobs package itself stays supported as host-side runtime extension for isolated apps
- **WebJobs package README + csproj description** — headline and NuGet description reflect the true role
- **publish-nuget.yml** — workflow input labels updated to "host-side package" / "worker-side package"

Familiar in-process / isolated worker terminology is preserved throughout for consumer clarity.