### PR TITLE
Fix Worker README and bump to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) an
 ### 1.1.1 — 2026-04-14
 
 #### Fixed
-- Worker package README on NuGet referenced the old `[SqsTrigger]` attribute name throughout (trigger examples, attribute docs, migration snippets) — would not compile against the 1.1.0 package which renamed it to `[SqsQueueTrigger]`. Updated all `[SqsTrigger]` usages to `[SqsQueueTrigger]`.
-- Stale `Version="1.0.0"` install snippet in the Worker package README updated to current version.
-- WebJobs package README on NuGet still showed pre-1.1.0 framing ("In-Process (WebJobs) hosting model"); now aligned with the host-side / worker-side framing introduced post-release in #82.
+- Worker package README on NuGet referenced the old `[SqsTrigger]` attribute name throughout (trigger examples, attribute docs, migration snippets) — would not compile against the 1.1.0 package which renamed it to `[SqsQueueTrigger]`. Updated all `[SqsTrigger]` usages to `[SqsQueueTrigger]` ([#83](https://github.com/laveeshb/azure-functions-sqs-extension/pull/83)).
+- Stale `Version="1.0.0"` install snippet in the Worker package README updated to current version ([#83](https://github.com/laveeshb/azure-functions-sqs-extension/pull/83)).
+- WebJobs package README on NuGet still showed pre-1.1.0 framing ("In-Process (WebJobs) hosting model"); now aligned with the host-side / worker-side framing ([#82](https://github.com/laveeshb/azure-functions-sqs-extension/pull/82), [#83](https://github.com/laveeshb/azure-functions-sqs-extension/pull/83)).
 
 ### 1.1.0 — 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) an
 
 ## .NET
 
+### 1.1.1 — 2026-04-14
+
+#### Fixed
+- Worker package README on NuGet referenced the old `[SqsTrigger]` attribute name throughout (trigger examples, attribute docs, migration snippets) — would not compile against the 1.1.0 package which renamed it to `[SqsQueueTrigger]`. Updated all `[SqsTrigger]` usages to `[SqsQueueTrigger]`.
+- Stale `Version="1.0.0"` install snippet in the Worker package README updated to current version.
+- WebJobs package README on NuGet still showed pre-1.1.0 framing ("In-Process (WebJobs) hosting model"); now aligned with the host-side / worker-side framing introduced post-release in #82.
+
 ### 1.1.0 — 2026-04-14
 
 #### Fixed

--- a/dotnet/MIGRATION_GUIDE.md
+++ b/dotnet/MIGRATION_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide helps you migrate between different versions of the Azure Functions SQS Extension.
 
-## Current State (v1.0.0)
+## Current State
 
 The Azure Functions SQS Extension provides **two separate packages**, following Microsoft's pattern for Azure Functions bindings:
 
@@ -34,7 +34,7 @@ Migrating from `AzureFunctions.Extension.SQS` (v2.x/v3.x) to `Extensions.Azure.W
 <PackageReference Include="AzureFunctions.Extension.SQS" Version="3.0.0" />
 
 <!-- Add new package -->
-<PackageReference Include="Extensions.Azure.WebJobs.SQS" Version="1.0.0" />
+<PackageReference Include="Extensions.Azure.WebJobs.SQS" Version="1.1.1" />
 ```
 
 #### 2. Update Namespace
@@ -105,7 +105,7 @@ Migrating from `AzureFunctions.Extension.SQS` to `Extensions.Azure.Functions.Wor
 <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.x.x" />
 
 <!-- Add isolated worker packages -->
-<PackageReference Include="Extensions.Azure.Functions.Worker.SQS" Version="1.0.0" />
+<PackageReference Include="Extensions.Azure.Functions.Worker.SQS" Version="1.1.1" />
 <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
 ```
@@ -315,16 +315,14 @@ Check your function logs and output queue for sent messages.
   services.AddSingleton<IAmazonSQS>(sp => new AmazonSQSClient());
   ```
 
-## Timeline Recommendations
+## Timeline
 
-- **2024-2025**: Migrate to isolated worker model for new projects
-- **By Q4 2025**: Plan migration for existing in-process apps
-- **By November 10, 2026**: Complete migration before Microsoft ends Azure Functions platform support for in-process model ([official timeline](https://aka.ms/azure-functions-retirements/in-process-model))
+- **November 10, 2026**: Microsoft ends Azure Functions platform support for the in-process hosting model ([official timeline](https://aka.ms/azure-functions-retirements/in-process-model)). Plan and complete your migration to the isolated worker model before this date.
 
 ## Resources
 
-- [In-Process Package README](./src/Azure.WebJobs.Extensions.SQS/README.md)
-- [Isolated Worker Package README](./src/Azure.Functions.Worker.Extensions.SQS/README.md)
+- [Host-side Package README (Extensions.Azure.WebJobs.SQS)](./src/Azure.WebJobs.Extensions.SQS/README.md)
+- [Worker-side Package README (Extensions.Azure.Functions.Worker.SQS)](./src/Azure.Functions.Worker.Extensions.SQS/README.md)
 - [Azure Functions Isolated Worker Guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
 - [Migrate to Isolated Worker (Microsoft Docs)](https://learn.microsoft.com/azure/azure-functions/migrate-dotnet-to-isolated-model)
 

--- a/dotnet/MIGRATION_GUIDE.md
+++ b/dotnet/MIGRATION_GUIDE.md
@@ -163,7 +163,7 @@ public void Run(
 // NEW (Isolated Worker)
 [Function("ProcessMessage")]
 public void Run(
-    [SqsTrigger(QueueUrl = "%SQS_QUEUE_URL%")] Message message,
+    [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message,
     FunctionContext context)
 {
     var logger = context.GetLogger("ProcessMessage");
@@ -255,7 +255,7 @@ Follow the same steps as **Scenario 2**, but:
 | Feature | In-Process | Isolated Worker |
 |---------|------------|-----------------|
 | **Package** | Extensions.Azure.WebJobs.SQS | Extensions.Azure.Functions.Worker.SQS |
-| **Trigger Attribute** | `[SqsQueueTrigger]` | `[SqsTrigger]` |
+| **Trigger Attribute** | `[SqsQueueTrigger]` | `[SqsQueueTrigger]` |
 | **Output Attribute** | `[SqsQueueOut]` with `out` parameter | Use `IAmazonSQS` directly |
 | **Function Attribute** | `[FunctionName]` | `[Function]` |
 | **Logging** | `ILogger` parameter | `FunctionContext.GetLogger()` |
@@ -305,7 +305,7 @@ Check your function logs and output queue for sent messages.
 
 **Solution:**
 - In-process: Use `[SqsQueueTrigger]` and `[SqsQueueOut]`
-- Isolated worker: Use `[SqsTrigger]`, no output attribute (use `IAmazonSQS`)
+- Isolated worker: Use `[SqsQueueTrigger]`, no output attribute (use `IAmazonSQS`)
 
 ### Issue: DI not working in isolated worker
 

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -136,7 +136,7 @@ public class SqsFunctions
 
     [Function("ProcessSQSMessage")]
     public void Run(
-        [SqsTrigger(QueueUrl = "%SQS_QUEUE_URL%")] Message message)
+        [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message)
     {
         _logger.LogInformation("Received message: {MessageId}", message.MessageId);
         _logger.LogInformation("Body: {Body}", message.Body);

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/Azure.Functions.Worker.Extensions.SQS.csproj
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/Azure.Functions.Worker.Extensions.SQS.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>Github</RepositoryType>
     <AssemblyName>Azure.Functions.Worker.Extensions.SQS</AssemblyName>
     <RootNamespace>Azure.Functions.Worker.Extensions.SQS</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Azure Functions Worker bindings extension SQS AWS Amazon isolated out-of-process</PackageTags>
     <PackageProjectUrl>https://github.com/laveeshb/azure-functions-sqs-extension</PackageProjectUrl>

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/README.md
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/README.md
@@ -67,7 +67,7 @@ public class SqsFunctions
 
     [Function(nameof(ProcessSqsMessage))]
     public void ProcessSqsMessage(
-        [SqsTrigger("%SQS_QUEUE_URL%")] Message message)
+        [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message)
     {
         _logger.LogInformation("Processing message: {MessageId}", message.MessageId);
         _logger.LogInformation("Message body: {Body}", message.Body);
@@ -176,12 +176,12 @@ The credential chain order:
 
 ## Attributes
 
-### SqsTriggerAttribute
+### SqsQueueTriggerAttribute
 
 Triggers a function when messages are available in an SQS queue.
 
 ```csharp
-[SqsTrigger(
+[SqsQueueTrigger(
     queueUrl: "%SQS_QUEUE_URL%",  // Required: Queue URL
     AWSKeyId = null,              // Optional: AWS Access Key ID
     AWSAccessKey = null,          // Optional: AWS Secret Access Key
@@ -200,7 +200,7 @@ Triggers a function when messages are available in an SQS queue.
 ```csharp
 [Function("ProcessFullMessage")]
 public void ProcessFullMessage(
-    [SqsTrigger("%SQS_QUEUE_URL%")] Message message,
+    [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message,
     FunctionContext context)
 {
     var logger = context.GetLogger("ProcessFullMessage");
@@ -222,7 +222,7 @@ public void ProcessFullMessage(
 ```csharp
 [Function("ProcessMessageBody")]
 public void ProcessMessageBody(
-    [SqsTrigger("%SQS_QUEUE_URL%")] string messageBody)
+    [SqsQueueTrigger("%SQS_QUEUE_URL%")] string messageBody)
 {
     // messageBody contains only the message body content
     Console.WriteLine($"Received: {messageBody}");
@@ -234,7 +234,7 @@ public void ProcessMessageBody(
 ```csharp
 [Function("ProcessAsync")]
 public async Task ProcessAsync(
-    [SqsTrigger("%SQS_QUEUE_URL%")] Message message)
+    [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message)
 {
     // Simulate async work
     await Task.Delay(100);
@@ -307,7 +307,7 @@ public class SqsSender
 <!-- Update packages -->
 <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
 <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
-<PackageReference Include="Extensions.Azure.Functions.Worker.SQS" Version="1.0.0" />
+<PackageReference Include="Extensions.Azure.Functions.Worker.SQS" Version="1.1.1" />
 ```
 
 #### 2. Update Configuration
@@ -336,7 +336,7 @@ public void Process(
 // New (Isolated Worker)
 [Function("Process")]
 public void Process(
-    [SqsTrigger("%SQS_QUEUE_URL%")] Message message)
+    [SqsQueueTrigger("%SQS_QUEUE_URL%")] Message message)
 {
     // Inject ILogger via constructor
 }
@@ -419,5 +419,5 @@ The isolated worker model is Microsoft's recommended approach for new Azure Func
 
 - [GitHub Repository](https://github.com/laveeshb/azure-functions-sqs-extension)
 - [NuGet Package](https://www.nuget.org/packages/Extensions.Azure.Functions.Worker.SQS)
-- [In-Process Package](https://www.nuget.org/packages/Extensions.Azure.WebJobs.SQS)
+- [Host-side Package (Extensions.Azure.WebJobs.SQS)](https://www.nuget.org/packages/Extensions.Azure.WebJobs.SQS)
 - [Report Issues](https://github.com/laveeshb/azure-functions-sqs-extension/issues)

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/WorkerExtensionStartup.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/WorkerExtensionStartup.cs
@@ -1,3 +1,3 @@
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
-[assembly: ExtensionInformation("Extensions.Azure.WebJobs.SQS", "1.1.0")]
+[assembly: ExtensionInformation("Extensions.Azure.WebJobs.SQS", "1.1.1")]

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>Github</RepositoryType>
     <AssemblyName>Azure.WebJobs.Extensions.SQS</AssemblyName>
     <RootNamespace>Azure.WebJobs.Extensions.SQS</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Azure Functions WebJobs bindings extension SQS AWS Amazon in-process</PackageTags>
     <PackageProjectUrl>https://github.com/laveeshb/azure-functions-sqs-extension</PackageProjectUrl>

--- a/dotnet/test/Extensions.SQS.Test.InProcess/README.md
+++ b/dotnet/test/Extensions.SQS.Test.InProcess/README.md
@@ -70,7 +70,7 @@ This test application demonstrates the **In-Process (WebJobs)** hosting model fo
 
 | Feature | In-Process (This App) | Isolated Worker |
 |---------|----------------------|-----------------|
-| Trigger Attribute | `SqsQueueTriggerAttribute` | `SqsTriggerAttribute` |
+| Trigger Attribute | `SqsQueueTriggerAttribute` | `SqsQueueTriggerAttribute` |
 | Output Attribute | `SqsQueueOutAttribute` | `SqsOutputAttribute` |
 | Output Pattern | `IAsyncCollector<T>` | Return values |
 | Runtime | In same process as host | Separate process |


### PR DESCRIPTION
## Summary
The Worker package README that shipped to NuGet in 1.1.0 still referenced the old `[SqsTrigger]` attribute throughout — examples, attribute docs, and migration snippets. Since 1.1.0 renamed the attribute to `[SqsQueueTrigger]`, anyone copy-pasting from the published NuGet README ends up with code that won't compile.

The README ships baked into the `.nupkg`, so fixing this requires a new package release. Bumping both packages to 1.1.1 (README-only patch) so the corrected READMEs land on NuGet.

### Changes
- **Worker package README** — all `[SqsTrigger]` updated to `[SqsQueueTrigger]`; section heading `SqsTriggerAttribute` → `SqsQueueTriggerAttribute`; stale `Version="1.0.0"` install snippet bumped to current; "In-Process Package" link label clarified to "Host-side Package"
- **dotnet/README** — isolated worker example used old attribute; updated
- **dotnet/MIGRATION_GUIDE** — fixed legacy → isolated migration snippet, key-differences table, and troubleshooting bullet to use `[SqsQueueTrigger]`; refreshed stale "Current State (v1.0.0)" header and `Version="1.0.0"` install snippets to 1.1.1; replaced stale 2024-2025 timeline (today is past Q4 2025) with a single Nov 10, 2026 milestone; "In-Process Package" / "Isolated Worker Package" link labels updated to host-side / worker-side framing for consistency with #82
- **In-process test README** — comparison table corrected
- **CHANGELOG** — added 1.1.1 entry with PR refs
- **Versions** — both csproj files bumped to 1.1.1; `ExtensionInformation` attribute updated to match

No source code changes — purely docs and version bumps.