### PR TITLE
Add Entra ID federation auth for SQS bindings (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ For .NET developers, this extension provides two packages supporting both hostin
 - ⚡ Trigger Azure Functions from SQS queue messages
 - 📤 Send messages to SQS queues from Azure Functions
 - 🎯 Multi-targeting: .NET 6.0 and .NET 8.0
-- 🔐 AWS credential chain support
+- 🔐 Password-less AWS auth via Entra ID federation (managed identity → AWS STS), plus AWS credential chain and explicit-key fallbacks
 - 🔄 Long polling and configurable batch processing
 - 🐳 LocalStack support for local development
 
 📖 **[See full .NET documentation](./dotnet/README.md)**
+🔐 **[Authentication guide](./docs/AUTHENTICATION.md)** — recommended setup uses managed identity, no AWS secret in Azure
 🧪 **[LocalStack testing guide](./dotnet/localstack/README.md)**
 
 ## 🐍 Python Extension

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -6,15 +6,60 @@ The SQS extension supports three ways for an Azure Function to authenticate to A
 |---|---------|------------------------|--------------------------|------------------|
 | 1 | **Entra ID federation via Managed Identity** | ✅ Yes | ✅ Yes | **Production. This is the recommended option.** |
 | 2 | Entra ID federation via App Registration (client secret) | ✅ Yes | ⚠️ No — Entra client secret required | When managed identity isn't available (e.g. some local dev setups) |
-| 3 | AWS access key + secret on the binding attribute | ❌ No — long-lived AWS key | ❌ No — long-lived AWS key in Azure | Backwards compatibility only |
+| 3 | AWS default credential chain (env vars / shared credentials file) | ❌ No — long-lived AWS key | ❌ No — long-lived AWS key in env vars | Existing deployments where the AWS key already lives in app settings / Key Vault |
+| 4 | AWS access key + secret on the binding attribute | ❌ No — long-lived AWS key | ❌ No — long-lived AWS key in Azure | Backwards compatibility only |
 
-The extension picks federation (option 1 or 2) when `AwsRoleArn` is set on the trigger or output binding. If `AwsRoleArn` is unset, it falls back to the AWS default credential chain (env vars, etc.) and finally to explicit keys if provided. Federation always wins when configured.
+The extension picks credentials in this priority order:
+
+1. **Federation (option 1 or 2)** when `AwsRoleArn` is set on the binding attribute.
+2. **Explicit keys (option 4)** when both `AWSKeyId` and `AWSAccessKey` are set on the attribute.
+3. **AWS default credential chain (option 3)** otherwise — the AWS SDK looks up `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars, the shared credentials file, etc.
+
+Federation always wins when configured.
 
 ---
 
 ## 1. Managed Identity → AWS (recommended, password-less)
 
 No secret lives anywhere in your Azure configuration. The Function App's managed identity gets an Entra ID token, which AWS STS exchanges for short-lived AWS credentials (default 1 hour, refreshed automatically).
+
+### How it works
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Azure Function App (managed identity enabled)             │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (1) DefaultAzureCredential.GetTokenAsync
+                           │      audience = api://AWSSecurityTokenService
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  Entra ID                                                  │
+│  - issues a JWT signed with the tenant key                 │
+│  - sub = managed identity object ID                        │
+│  - aud = api://AWSSecurityTokenService                     │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (2) Entra JWT
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AWS STS — AssumeRoleWithWebIdentity                       │
+│  - validates JWT signature via the IAM OIDC provider       │
+│  - checks trust policy: aud + sub + issuer must match      │
+│  - returns temporary credentials (1h default, refreshed)   │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (3) AccessKey + Secret + SessionToken
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AmazonSQSClient (inside the Function App)                 │
+│  - signs SQS calls with the temporary credentials          │
+│  - the EntraIdFederatedCredentials class auto-refreshes    │
+│    the token before expiry, so step (1)–(3) repeats        │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (4) ReceiveMessage / SendMessage / DeleteMessage
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AWS SQS                                                   │
+└────────────────────────────────────────────────────────────┘
+```
 
 ### One-time AWS setup
 
@@ -74,6 +119,36 @@ Same federation flow as option 1, but the Entra token is obtained using an Entra
 
 When to choose this over option 1: usually only when managed identity isn't an option (some local dev scenarios; environments where you need a single identity that works across hosts).
 
+### How it works
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Azure Function App                                        │
+│  settings: EntraTenantId, EntraClientId,                   │
+│            EntraClientSecret  (Key Vault reference)        │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (1) ClientSecretCredential.GetTokenAsync
+                           │      using tenant + client id + client secret
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  Entra ID (token endpoint)                                 │
+│  - validates client_secret against the app registration    │
+│  - issues a JWT signed with the tenant key                 │
+│  - sub = app registration object ID                        │
+│  - aud = api://AWSSecurityTokenService                     │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (2) Entra JWT
+                           ▼
+       (steps 3–5 are identical to option 1: AWS STS validates
+        the JWT, returns temporary AWS credentials, the SQS
+        client signs API calls with them)
+
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AWS SQS                                                   │
+└────────────────────────────────────────────────────────────┘
+```
+
 ### AWS setup
 
 Same as option 1, but the trust policy's `sub` condition uses the app registration's object ID (or the federated subject your IdP issues).
@@ -99,9 +174,75 @@ public void Run(
 
 ---
 
-## 3. AWS access key + secret (legacy)
+## 3. AWS default credential chain
+
+Leave the AWS-specific attribute properties unset and let the AWS SDK's default credential provider chain locate credentials. On Azure (no EC2/ECS/EKS infrastructure), the practical pickup paths are:
+
+- Environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`
+- A shared credentials file (`~/.aws/credentials`) mounted into the Function App
+
+Set those env vars as Function App settings (Key Vault references recommended for the secret).
+
+### How it works
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Azure Function App                                        │
+│  env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY             │
+│       (Key Vault reference recommended for the secret)     │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (1) AWS SDK default credential chain
+                           │      walks env vars / shared file
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AmazonSQSClient                                           │
+│  - signs SQS calls with the long-lived credentials         │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (2) ReceiveMessage / SendMessage
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AWS SQS                                                   │
+└────────────────────────────────────────────────────────────┘
+```
+
+```csharp
+public void Run(
+    [SqsQueueTrigger(QueueUrl = "%SQS_QUEUE_URL%")]
+    Message message,
+    ILogger logger)
+{
+    // ...
+}
+```
+
+The AWS secret still lives in Azure (just in env vars rather than the binding attribute). The advantage over option 4 is that you can rotate the key by editing app settings without redeploying code, and standard AWS tooling (CLI, SDKs, samples) "just works" in the same environment.
+
+## 4. AWS access key + secret on the attribute (legacy)
 
 Long-lived AWS credentials passed directly to the binding attribute. **Avoid for new code.** Kept for backwards compatibility with existing deployments.
+
+### How it works
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Azure Function App                                        │
+│  binding attribute: AWSKeyId = "%AWS_ACCESS_KEY_ID%"       │
+│                     AWSAccessKey = "%AWS_SECRET_ACCESS_KEY%"│
+│  app settings:      AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY│
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (1) %VAR% interpolation reads env vars
+                           │      into the attribute at startup
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AmazonSQSClient                                           │
+│  - constructed with BasicAWSCredentials(key, secret)       │
+└──────────────────────────┬─────────────────────────────────┘
+                           │  (2) ReceiveMessage / SendMessage
+                           ▼
+┌────────────────────────────────────────────────────────────┐
+│  AWS SQS                                                   │
+└────────────────────────────────────────────────────────────┘
+```
 
 ```csharp
 public void Run(
@@ -116,9 +257,7 @@ public void Run(
 }
 ```
 
-Or omit the attribute properties entirely and let the AWS SDK's default credential chain pick up `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from environment variables.
-
-Either way, a long-lived AWS secret lives in your Azure configuration. Rotate it on a regular cadence, and migrate to option 1 when you can.
+Same security posture as option 3 (a long-lived AWS secret lives in your Azure configuration). Rotate it on a regular cadence, and migrate to option 1 when you can.
 
 ---
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,0 +1,163 @@
+# Authentication
+
+The SQS extension supports three ways for an Azure Function to authenticate to AWS. They are listed below in order of recommendation.
+
+| # | Pattern | Stores AWS secret? | Stores any secret in Azure? | Recommended for |
+|---|---------|--------------------|------------------------------|------------------|
+| 1 | **Entra ID federation via Managed Identity** | ❌ No | ❌ No | **Production. This is the recommended option.** |
+| 2 | Entra ID federation via App Registration (client secret) | ❌ No | ⚠️ Entra client secret only | When managed identity isn't available (e.g. some local dev setups) |
+| 3 | AWS access key + secret on the binding attribute | ⚠️ Yes (long-lived) | ⚠️ Yes (long-lived AWS key) | Backwards compatibility only |
+
+The extension picks federation (option 1 or 2) when `AwsRoleArn` is set on the trigger or output binding. If `AwsRoleArn` is unset, it falls back to the AWS default credential chain (env vars, etc.) and finally to explicit keys if provided. Federation always wins when configured.
+
+---
+
+## 1. Managed Identity → AWS (recommended, password-less)
+
+No secret lives anywhere in your Azure configuration. The Function App's managed identity gets an Entra ID token, which AWS STS exchanges for short-lived AWS credentials (default 1 hour, refreshed automatically).
+
+### One-time AWS setup
+
+Create an OIDC identity provider in IAM:
+
+- **Provider URL**: `https://sts.windows.net/<your-tenant-id>/`
+- **Audience**: `api://AWSSecurityTokenService`
+
+Create an IAM role with this trust policy (replace tenant ID and managed identity object ID):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::123456789012:oidc-provider/sts.windows.net/<tenant-id>/"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "sts.windows.net/<tenant-id>/:aud": "api://AWSSecurityTokenService",
+        "sts.windows.net/<tenant-id>/:sub": "<managed-identity-object-id>"
+      }
+    }
+  }]
+}
+```
+
+Attach an SQS permission policy to the role granting at least `sqs:ReceiveMessage`, `sqs:DeleteMessage` (trigger) and/or `sqs:SendMessage` (output) on your queue ARN.
+
+### One-time Azure setup
+
+Enable a system-assigned (or user-assigned) managed identity on the Function App.
+
+### Function code
+
+```csharp
+public void Run(
+    [SqsQueueTrigger(
+        QueueUrl = "%SQS_QUEUE_URL%",
+        AwsRoleArn = "%AWS_ROLE_ARN%")]
+    Message message,
+    ILogger logger)
+{
+    // ...
+}
+```
+
+In app settings: `SQS_QUEUE_URL` and `AWS_ROLE_ARN` (the role created above). **No AWS credentials anywhere.**
+
+---
+
+## 2. App Registration → AWS
+
+Same federation flow as option 1, but the Entra token is obtained using an Entra app registration's client secret instead of the Function App's managed identity. The AWS side still gets only short-lived STS credentials — but you do have to store the Entra client secret in Azure (Key Vault reference recommended).
+
+When to choose this over option 1: usually only when managed identity isn't an option (some local dev scenarios; environments where you need a single identity that works across hosts).
+
+### AWS setup
+
+Same as option 1, but the trust policy's `sub` condition uses the app registration's object ID (or the federated subject your IdP issues).
+
+### Function code
+
+```csharp
+public void Run(
+    [SqsQueueTrigger(
+        QueueUrl = "%SQS_QUEUE_URL%",
+        AwsRoleArn = "%AWS_ROLE_ARN%",
+        EntraTenantId = "%ENTRA_TENANT_ID%",
+        EntraClientId = "%ENTRA_CLIENT_ID%",
+        EntraClientSecret = "@Microsoft.KeyVault(SecretUri=https://my-vault.vault.azure.net/secrets/entra-client-secret/)")]
+    Message message,
+    ILogger logger)
+{
+    // ...
+}
+```
+
+> **Always reference `EntraClientSecret` from Key Vault** — never as a literal app setting. The example above uses an Azure Key Vault reference.
+
+---
+
+## 3. AWS access key + secret (legacy)
+
+Long-lived AWS credentials passed directly to the binding attribute. **Avoid for new code.** Kept for backwards compatibility with existing deployments.
+
+```csharp
+public void Run(
+    [SqsQueueTrigger(
+        QueueUrl = "%SQS_QUEUE_URL%",
+        AWSKeyId = "%AWS_ACCESS_KEY_ID%",
+        AWSAccessKey = "%AWS_SECRET_ACCESS_KEY%")]
+    Message message,
+    ILogger logger)
+{
+    // ...
+}
+```
+
+Or omit the attribute properties entirely and let the AWS SDK's default credential chain pick up `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from environment variables.
+
+Either way, a long-lived AWS secret lives in your Azure configuration. Rotate it on a regular cadence, and migrate to option 1 when you can.
+
+---
+
+## All federation knobs
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `AwsRoleArn` | _(unset)_ | IAM role to assume. Setting this enables federation. |
+| `AwsStsAudience` | `api://AWSSecurityTokenService` | Token audience. Must match the IAM trust policy. |
+| `AwsRoleSessionName` | `azure-functions-sqs` | Surfaces in CloudTrail for auditing. |
+| `AwsSessionDurationSeconds` | `3600` | STS session length. Must be ≤ the role's `MaxSessionDuration`. |
+| `EntraTenantId` | _(unset)_ | Entra tenant for option 2. Leave unset for option 1. |
+| `EntraClientId` | _(unset)_ | Entra app registration client ID for option 2. |
+| `EntraClientSecret` | _(unset)_ | Entra app registration secret for option 2. **Use a Key Vault reference.** |
+
+These properties exist on `SqsQueueTriggerAttribute`, `SqsQueueOutAttribute` (host-side / in-process) and `SqsQueueTriggerAttribute`, `SqsOutputAttribute` (worker-side / isolated).
+
+---
+
+## Local development
+
+When `AwsRoleArn` is set but no app-reg fields are provided, the extension uses `DefaultAzureCredential`, which transparently picks up:
+
+- The Function App's managed identity (in production)
+- `az login` credentials (local dev with the Azure CLI)
+- Visual Studio / VS Code signed-in identity
+
+Add your developer Entra object ID as an additional principal in the IAM role's trust policy condition (`sts.windows.net/<tenant>/:sub` → the developer's object ID) and federation works locally with no code change.
+
+If you can't federate the developer identity, set `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` env vars locally — `DefaultAzureCredential` picks those up via its `EnvironmentCredential` step.
+
+---
+
+## Required IAM permissions
+
+The IAM role assumed via federation needs:
+
+- `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:GetQueueAttributes` — for the trigger
+- `sqs:SendMessage` — for the output binding
+- `sqs:GetQueueUrl` — useful when the queue URL isn't hard-coded
+
+Scope the resource to your specific queue ARN.

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -2,11 +2,11 @@
 
 The SQS extension supports three ways for an Azure Function to authenticate to AWS. They are listed below in order of recommendation.
 
-| # | Pattern | Stores AWS secret? | Stores any secret in Azure? | Recommended for |
-|---|---------|--------------------|------------------------------|------------------|
-| 1 | **Entra ID federation via Managed Identity** | ❌ No | ❌ No | **Production. This is the recommended option.** |
-| 2 | Entra ID federation via App Registration (client secret) | ❌ No | ⚠️ Entra client secret only | When managed identity isn't available (e.g. some local dev setups) |
-| 3 | AWS access key + secret on the binding attribute | ⚠️ Yes (long-lived) | ⚠️ Yes (long-lived AWS key) | Backwards compatibility only |
+| # | Pattern | Password-less for AWS? | Password-less in Azure? | Recommended for |
+|---|---------|------------------------|--------------------------|------------------|
+| 1 | **Entra ID federation via Managed Identity** | ✅ Yes | ✅ Yes | **Production. This is the recommended option.** |
+| 2 | Entra ID federation via App Registration (client secret) | ✅ Yes | ⚠️ No — Entra client secret required | When managed identity isn't available (e.g. some local dev setups) |
+| 3 | AWS access key + secret on the binding attribute | ❌ No — long-lived AWS key | ❌ No — long-lived AWS key in Azure | Backwards compatibility only |
 
 The extension picks federation (option 1 or 2) when `AwsRoleArn` is set on the trigger or output binding. If `AwsRoleArn` is unset, it falls back to the AWS default credential chain (env vars, etc.) and finally to explicit keys if provided. Federation always wins when configured.
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -261,6 +261,34 @@ Same security posture as option 3 (a long-lived AWS secret lives in your Azure c
 
 ---
 
+## Storing secrets in Azure Key Vault
+
+For options 2, 3, and 4 — anywhere a secret would otherwise sit in a Function App setting in plaintext — back the setting with a Key Vault reference instead. The Azure Functions runtime resolves `@Microsoft.KeyVault(SecretUri=...)` at app startup, so the literal secret never appears in your config blade and the extension only sees the resolved value. (Option 1 has no secret to store, so this section doesn't apply.)
+
+### How
+
+For each secret app setting, set the value to a Key Vault reference:
+
+```
+@Microsoft.KeyVault(SecretUri=https://my-vault.vault.azure.net/secrets/<name>/)
+```
+
+Per option:
+
+- **Option 2 (Entra client secret)** — already shown in the section 2 example. The `EntraClientSecret` attribute reads a Key Vault-backed app setting.
+- **Option 3 (AWS credential chain)** — set the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` app settings as Key Vault references. The AWS SDK reads the resolved env vars.
+- **Option 4 (explicit keys on attribute)** — same as option 3, but the attribute uses `%AWS_SECRET_ACCESS_KEY%` interpolation to reach the resolved env var.
+
+### Prerequisite
+
+The Function App's managed identity needs read access to the vault — assign the `Key Vault Secrets User` role (RBAC) or an access policy with `get` on secrets.
+
+### Caveat: rotation
+
+Key Vault references resolve at app startup, not per request. Rotations take effect on restart. The Functions runtime also refreshes references periodically (every ~24h on supported plans), but for short-rotation secrets you'd need custom `SecretClient` code in the function body — outside what the binding mechanism handles. Option 1 sidesteps this entirely: short-lived STS credentials are refreshed automatically by the extension, no app restart required.
+
+---
+
 ## All federation knobs
 
 | Property | Default | Description |

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -6,8 +6,8 @@ The SQS extension supports three ways for an Azure Function to authenticate to A
 |---|---------|------------------------|--------------------------|------------------|
 | 1 | **Entra ID federation via Managed Identity** | ✅ Yes | ✅ Yes | **Production. This is the recommended option.** |
 | 2 | Entra ID federation via App Registration (client secret) | ✅ Yes | ⚠️ No — Entra client secret required | When managed identity isn't available (e.g. some local dev setups) |
-| 3 | AWS default credential chain (env vars / shared credentials file) | ❌ No — long-lived AWS key | ❌ No — long-lived AWS key in env vars | Existing deployments where the AWS key already lives in app settings / Key Vault |
-| 4 | AWS access key + secret on the binding attribute | ❌ No — long-lived AWS key | ❌ No — long-lived AWS key in Azure | Backwards compatibility only |
+| 3 | AWS default credential chain (env vars / shared credentials file) | ⚠️ No — long-lived AWS key | ⚠️ No — long-lived AWS key in env vars | Existing deployments where the AWS key already lives in app settings / Key Vault |
+| 4 | AWS access key + secret on the binding attribute | ⚠️ No — long-lived AWS key | ⚠️ No — long-lived AWS key in Azure | Backwards compatibility only |
 
 The extension picks credentials in this priority order:
 

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsOutputAttribute.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsOutputAttribute.cs
@@ -37,4 +37,52 @@ public sealed class SqsOutputAttribute : OutputBindingAttribute
     /// Gets or sets the AWS Region (e.g., "us-east-1"). If not specified, uses AWS credential chain.
     /// </summary>
     public string? Region { get; set; }
+
+    /// <summary>
+    /// AWS IAM Role ARN to assume via Entra ID OIDC federation. When set, the extension
+    /// authenticates by exchanging an Entra ID token (from the Function App's managed
+    /// identity, or DefaultAzureCredential locally) for temporary AWS credentials via
+    /// STS AssumeRoleWithWebIdentity — no AWS secret needs to be stored. Takes precedence
+    /// over AWSKeyId/AWSAccessKey and the AWS default credential chain.
+    /// </summary>
+    public string? AwsRoleArn { get; set; }
+
+    /// <summary>
+    /// Entra ID token audience used when federating to AWS. Defaults to
+    /// "api://AWSSecurityTokenService". Must match the AWS IAM trust policy.
+    /// </summary>
+    public string AwsStsAudience { get; set; } = "api://AWSSecurityTokenService";
+
+    /// <summary>
+    /// Session name passed to STS AssumeRoleWithWebIdentity. Surfaces in CloudTrail
+    /// for auditing. Defaults to "azure-functions-sqs".
+    /// </summary>
+    public string AwsRoleSessionName { get; set; } = "azure-functions-sqs";
+
+    /// <summary>
+    /// Duration in seconds for the assumed-role session. Must be between 900 (15 min)
+    /// and the maximum configured on the IAM role (default 3600). Defaults to 3600.
+    /// </summary>
+    public int AwsSessionDurationSeconds { get; set; } = 3600;
+
+    /// <summary>
+    /// Entra ID (Azure AD) tenant ID for an app registration used to obtain the federated
+    /// token. Optional. When set together with EntraClientId and EntraClientSecret, the
+    /// extension uses ClientSecretCredential. If left unset, DefaultAzureCredential is used,
+    /// which picks up the Function App's managed identity in production — the recommended,
+    /// password-less option.
+    /// </summary>
+    public string? EntraTenantId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client ID for an app registration. See <see cref="EntraTenantId"/>.
+    /// </summary>
+    public string? EntraClientId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client secret for an app registration. Should be referenced from
+    /// Azure Key Vault rather than stored as a literal app setting. Prefer managed identity
+    /// (leave this unset) over an app registration with a secret.
+    /// </summary>
+    public string? EntraClientSecret { get; set; }
 }

--- a/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsQueueTriggerAttribute.cs
+++ b/dotnet/src/Azure.Functions.Worker.Extensions.SQS/SqsQueueTriggerAttribute.cs
@@ -62,4 +62,52 @@ public sealed class SqsQueueTriggerAttribute : TriggerBindingAttribute
     /// Gets or sets whether to automatically delete messages after successful processing. Default is true.
     /// </summary>
     public bool AutoDelete { get; set; } = true;
+
+    /// <summary>
+    /// AWS IAM Role ARN to assume via Entra ID OIDC federation. When set, the extension
+    /// authenticates by exchanging an Entra ID token (from the Function App's managed
+    /// identity, or DefaultAzureCredential locally) for temporary AWS credentials via
+    /// STS AssumeRoleWithWebIdentity — no AWS secret needs to be stored. Takes precedence
+    /// over AWSKeyId/AWSAccessKey and the AWS default credential chain.
+    /// </summary>
+    public string? AwsRoleArn { get; set; }
+
+    /// <summary>
+    /// Entra ID token audience used when federating to AWS. Defaults to
+    /// "api://AWSSecurityTokenService". Must match the AWS IAM trust policy.
+    /// </summary>
+    public string AwsStsAudience { get; set; } = "api://AWSSecurityTokenService";
+
+    /// <summary>
+    /// Session name passed to STS AssumeRoleWithWebIdentity. Surfaces in CloudTrail
+    /// for auditing. Defaults to "azure-functions-sqs".
+    /// </summary>
+    public string AwsRoleSessionName { get; set; } = "azure-functions-sqs";
+
+    /// <summary>
+    /// Duration in seconds for the assumed-role session. Must be between 900 (15 min)
+    /// and the maximum configured on the IAM role (default 3600). Defaults to 3600.
+    /// </summary>
+    public int AwsSessionDurationSeconds { get; set; } = 3600;
+
+    /// <summary>
+    /// Entra ID (Azure AD) tenant ID for an app registration used to obtain the federated
+    /// token. Optional. When set together with EntraClientId and EntraClientSecret, the
+    /// extension uses ClientSecretCredential. If left unset, DefaultAzureCredential is used,
+    /// which picks up the Function App's managed identity in production — the recommended,
+    /// password-less option.
+    /// </summary>
+    public string? EntraTenantId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client ID for an app registration. See <see cref="EntraTenantId"/>.
+    /// </summary>
+    public string? EntraClientId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client secret for an app registration. Should be referenced from
+    /// Azure Key Vault rather than stored as a literal app setting. Prefer managed identity
+    /// (leave this unset) over an app registration with a secret.
+    /// </summary>
+    public string? EntraClientSecret { get; set; }
 }

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Auth/EntraIdFederatedCredentials.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Auth/EntraIdFederatedCredentials.cs
@@ -7,6 +7,7 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
+using Microsoft.Extensions.Logging;
 using AzureCore = global::Azure.Core;
 using AzureIdentity = global::Azure.Identity;
 
@@ -17,11 +18,14 @@ using AzureIdentity = global::Azure.Identity;
 /// </summary>
 public sealed class EntraIdFederatedCredentials : RefreshingAWSCredentials
 {
+    internal const int MinSessionDurationSeconds = 900;
+
     private readonly string _roleArn;
     private readonly string _audience;
     private readonly string _roleSessionName;
     private readonly int _sessionDurationSeconds;
     private readonly RegionEndpoint _stsRegion;
+    private readonly ILogger? _logger;
     private readonly Func<AzureCore.TokenRequestContext, CancellationToken, ValueTask<AzureCore.AccessToken>> _getEntraToken;
     private readonly Func<AssumeRoleWithWebIdentityRequest, CancellationToken, Task<AssumeRoleWithWebIdentityResponse>> _assumeRoleAsync;
 
@@ -31,14 +35,23 @@ public sealed class EntraIdFederatedCredentials : RefreshingAWSCredentials
         string roleSessionName,
         int sessionDurationSeconds,
         RegionEndpoint stsRegion,
+        ILogger? logger = null,
         Func<AzureCore.TokenRequestContext, CancellationToken, ValueTask<AzureCore.AccessToken>>? getEntraToken = null,
         Func<AssumeRoleWithWebIdentityRequest, CancellationToken, Task<AssumeRoleWithWebIdentityResponse>>? assumeRoleAsync = null)
     {
         _roleArn = roleArn ?? throw new ArgumentNullException(nameof(roleArn));
         _audience = audience ?? throw new ArgumentNullException(nameof(audience));
         _roleSessionName = roleSessionName ?? throw new ArgumentNullException(nameof(roleSessionName));
+        if (sessionDurationSeconds < MinSessionDurationSeconds)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(sessionDurationSeconds),
+                sessionDurationSeconds,
+                $"STS requires an assumed-role session of at least {MinSessionDurationSeconds} seconds.");
+        }
         _sessionDurationSeconds = sessionDurationSeconds;
         _stsRegion = stsRegion ?? throw new ArgumentNullException(nameof(stsRegion));
+        _logger = logger;
         _getEntraToken = getEntraToken ?? new AzureIdentity.DefaultAzureCredential().GetTokenAsync;
         _assumeRoleAsync = assumeRoleAsync ?? DefaultAssumeRoleAsync;
     }
@@ -53,19 +66,42 @@ public sealed class EntraIdFederatedCredentials : RefreshingAWSCredentials
 
     protected override async Task<CredentialsRefreshState> GenerateNewCredentialsAsync()
     {
-        var entraToken = await _getEntraToken(
-            new AzureCore.TokenRequestContext(new[] { $"{_audience}/.default" }),
-            CancellationToken.None).ConfigureAwait(false);
+        AzureCore.AccessToken entraToken;
+        try
+        {
+            entraToken = await _getEntraToken(
+                new AzureCore.TokenRequestContext(new[] { $"{_audience}/.default" }),
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to acquire Entra ID token for audience {Audience}.", _audience);
+            throw;
+        }
 
-        var stsResponse = await _assumeRoleAsync(
-            new AssumeRoleWithWebIdentityRequest
-            {
-                RoleArn = _roleArn,
-                RoleSessionName = _roleSessionName,
-                WebIdentityToken = entraToken.Token,
-                DurationSeconds = _sessionDurationSeconds,
-            },
-            CancellationToken.None).ConfigureAwait(false);
+        AssumeRoleWithWebIdentityResponse stsResponse;
+        try
+        {
+            stsResponse = await _assumeRoleAsync(
+                new AssumeRoleWithWebIdentityRequest
+                {
+                    RoleArn = _roleArn,
+                    RoleSessionName = _roleSessionName,
+                    WebIdentityToken = entraToken.Token,
+                    DurationSeconds = _sessionDurationSeconds,
+                },
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "STS AssumeRoleWithWebIdentity failed for role {RoleArn}.", _roleArn);
+            throw;
+        }
+
+        _logger?.LogDebug(
+            "Refreshed AWS credentials via Entra federation for role {RoleArn}; expires at {Expiration:O}.",
+            _roleArn,
+            stsResponse.Credentials.Expiration);
 
         return new CredentialsRefreshState(
             new ImmutableCredentials(

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Auth/EntraIdFederatedCredentials.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Auth/EntraIdFederatedCredentials.cs
@@ -1,0 +1,88 @@
+namespace Azure.WebJobs.Extensions.SQS.Auth;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.Runtime;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using AzureCore = global::Azure.Core;
+using AzureIdentity = global::Azure.Identity;
+
+/// <summary>
+/// AWS credentials provider that exchanges an Entra ID (Azure AD) access token for
+/// temporary AWS credentials via STS AssumeRoleWithWebIdentity. Refreshes automatically
+/// before expiry. Used when <c>AwsRoleArn</c> is set on the SQS trigger or output binding.
+/// </summary>
+public sealed class EntraIdFederatedCredentials : RefreshingAWSCredentials
+{
+    private readonly string _roleArn;
+    private readonly string _audience;
+    private readonly string _roleSessionName;
+    private readonly int _sessionDurationSeconds;
+    private readonly RegionEndpoint _stsRegion;
+    private readonly Func<AzureCore.TokenRequestContext, CancellationToken, ValueTask<AzureCore.AccessToken>> _getEntraToken;
+    private readonly Func<AssumeRoleWithWebIdentityRequest, CancellationToken, Task<AssumeRoleWithWebIdentityResponse>> _assumeRoleAsync;
+
+    public EntraIdFederatedCredentials(
+        string roleArn,
+        string audience,
+        string roleSessionName,
+        int sessionDurationSeconds,
+        RegionEndpoint stsRegion,
+        Func<AzureCore.TokenRequestContext, CancellationToken, ValueTask<AzureCore.AccessToken>>? getEntraToken = null,
+        Func<AssumeRoleWithWebIdentityRequest, CancellationToken, Task<AssumeRoleWithWebIdentityResponse>>? assumeRoleAsync = null)
+    {
+        _roleArn = roleArn ?? throw new ArgumentNullException(nameof(roleArn));
+        _audience = audience ?? throw new ArgumentNullException(nameof(audience));
+        _roleSessionName = roleSessionName ?? throw new ArgumentNullException(nameof(roleSessionName));
+        _sessionDurationSeconds = sessionDurationSeconds;
+        _stsRegion = stsRegion ?? throw new ArgumentNullException(nameof(stsRegion));
+        _getEntraToken = getEntraToken ?? new AzureIdentity.DefaultAzureCredential().GetTokenAsync;
+        _assumeRoleAsync = assumeRoleAsync ?? DefaultAssumeRoleAsync;
+    }
+
+    protected override CredentialsRefreshState GenerateNewCredentials()
+    {
+        // The AWS SDK uses GetCredentialsAsync on the async request path (which is
+        // what AmazonSQSClient.ReceiveMessageAsync hits). This sync override exists
+        // for any sync callers; offload to the thread pool to avoid sync-context deadlocks.
+        return Task.Run(GenerateNewCredentialsAsync).GetAwaiter().GetResult();
+    }
+
+    protected override async Task<CredentialsRefreshState> GenerateNewCredentialsAsync()
+    {
+        var entraToken = await _getEntraToken(
+            new AzureCore.TokenRequestContext(new[] { $"{_audience}/.default" }),
+            CancellationToken.None).ConfigureAwait(false);
+
+        var stsResponse = await _assumeRoleAsync(
+            new AssumeRoleWithWebIdentityRequest
+            {
+                RoleArn = _roleArn,
+                RoleSessionName = _roleSessionName,
+                WebIdentityToken = entraToken.Token,
+                DurationSeconds = _sessionDurationSeconds,
+            },
+            CancellationToken.None).ConfigureAwait(false);
+
+        return new CredentialsRefreshState(
+            new ImmutableCredentials(
+                stsResponse.Credentials.AccessKeyId,
+                stsResponse.Credentials.SecretAccessKey,
+                stsResponse.Credentials.SessionToken),
+            stsResponse.Credentials.Expiration);
+    }
+
+    private async Task<AssumeRoleWithWebIdentityResponse> DefaultAssumeRoleAsync(
+        AssumeRoleWithWebIdentityRequest request,
+        CancellationToken cancellationToken)
+    {
+        // STS AssumeRoleWithWebIdentity is unauthenticated — the web identity token
+        // is the authentication. Anonymous credentials prevent the SDK from looking
+        // for AWS credentials it doesn't need.
+        using var stsClient = new AmazonSecurityTokenServiceClient(new AnonymousAWSCredentials(), _stsRegion);
+        return await stsClient.AssumeRoleWithWebIdentityAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Azure.WebJobs.Extensions.SQS.csproj
@@ -24,7 +24,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.55" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Common/AmazonSQSClientFactory.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Common/AmazonSQSClientFactory.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Azure.WebJobs.Extensions.SQS;
 
 using System;
@@ -6,6 +6,9 @@ using System.Linq;
 using Amazon;
 using Amazon.Runtime;
 using Amazon.SQS;
+using Azure.WebJobs.Extensions.SQS.Auth;
+using AzureCore = global::Azure.Core;
+using AzureIdentity = global::Azure.Identity;
 
 public class AmazonSQSClientFactory
 {
@@ -15,7 +18,14 @@ public class AmazonSQSClientFactory
             queueUrl: triggerParameters.QueueUrl,
             awsKeyId: triggerParameters.AWSKeyId,
             awsAccessKey: triggerParameters.AWSAccessKey,
-            regionOverride: triggerParameters.Region);
+            regionOverride: triggerParameters.Region,
+            awsRoleArn: triggerParameters.AwsRoleArn,
+            awsStsAudience: triggerParameters.AwsStsAudience,
+            awsRoleSessionName: triggerParameters.AwsRoleSessionName,
+            awsSessionDurationSeconds: triggerParameters.AwsSessionDurationSeconds,
+            entraTenantId: triggerParameters.EntraTenantId,
+            entraClientId: triggerParameters.EntraClientId,
+            entraClientSecret: triggerParameters.EntraClientSecret);
     }
 
     public static AmazonSQSClient Build(SqsQueueOutAttribute outParameters)
@@ -24,16 +34,50 @@ public class AmazonSQSClientFactory
             queueUrl: outParameters.QueueUrl,
             awsKeyId: outParameters.AWSKeyId,
             awsAccessKey: outParameters.AWSAccessKey,
-            regionOverride: outParameters.Region);
+            regionOverride: outParameters.Region,
+            awsRoleArn: outParameters.AwsRoleArn,
+            awsStsAudience: outParameters.AwsStsAudience,
+            awsRoleSessionName: outParameters.AwsRoleSessionName,
+            awsSessionDurationSeconds: outParameters.AwsSessionDurationSeconds,
+            entraTenantId: outParameters.EntraTenantId,
+            entraClientId: outParameters.EntraClientId,
+            entraClientSecret: outParameters.EntraClientSecret);
     }
 
-    private static AmazonSQSClient Build(string queueUrl, string? awsKeyId, string? awsAccessKey, string? regionOverride)
+    private static AmazonSQSClient Build(
+        string queueUrl,
+        string? awsKeyId,
+        string? awsAccessKey,
+        string? regionOverride,
+        string? awsRoleArn,
+        string awsStsAudience,
+        string awsRoleSessionName,
+        int awsSessionDurationSeconds,
+        string? entraTenantId,
+        string? entraClientId,
+        string? entraClientSecret)
     {
         // Extract region from queue URL
         var sqsRegion = ExtractRegionFromQueueUrl(queueUrl);
-        var region = !string.IsNullOrEmpty(regionOverride) 
+        var region = !string.IsNullOrEmpty(regionOverride)
             ? RegionEndpoint.GetBySystemName(regionOverride)
             : RegionEndpoint.EnumerableAllRegions.Single(r => r.SystemName.Equals(sqsRegion, StringComparison.OrdinalIgnoreCase));
+
+        // Entra ID federation takes precedence when a role ARN is provided.
+        // No long-lived AWS secret is stored — an Entra token is exchanged for
+        // temporary AWS credentials via STS AssumeRoleWithWebIdentity.
+        if (!string.IsNullOrEmpty(awsRoleArn))
+        {
+            var entraCredential = BuildEntraCredential(entraTenantId, entraClientId, entraClientSecret);
+            var federatedCredentials = new EntraIdFederatedCredentials(
+                roleArn: awsRoleArn!,
+                audience: awsStsAudience,
+                roleSessionName: awsRoleSessionName,
+                sessionDurationSeconds: awsSessionDurationSeconds,
+                stsRegion: region,
+                getEntraToken: entraCredential.GetTokenAsync);
+            return new AmazonSQSClient(federatedCredentials, region);
+        }
 
         // Use AWS credential chain if no explicit credentials provided
         // This supports: Environment variables, ECS container credentials, EC2 instance profile, etc.
@@ -47,12 +91,34 @@ public class AmazonSQSClientFactory
         return new AmazonSQSClient(credentials, region);
     }
 
+    /// <summary>
+    /// Selects the Entra credential used to obtain the federation token.
+    /// If all three app-registration fields are provided, uses ClientSecretCredential.
+    /// Otherwise falls back to DefaultAzureCredential, which picks up the Function App's
+    /// managed identity in production (the recommended, password-less option) and the
+    /// developer's Entra identity (e.g. via az login or Visual Studio) locally.
+    /// </summary>
+    internal static AzureCore.TokenCredential BuildEntraCredential(
+        string? entraTenantId,
+        string? entraClientId,
+        string? entraClientSecret)
+    {
+        if (!string.IsNullOrEmpty(entraTenantId)
+            && !string.IsNullOrEmpty(entraClientId)
+            && !string.IsNullOrEmpty(entraClientSecret))
+        {
+            return new AzureIdentity.ClientSecretCredential(entraTenantId, entraClientId, entraClientSecret);
+        }
+
+        return new AzureIdentity.DefaultAzureCredential();
+    }
+
     private static string ExtractRegionFromQueueUrl(string queueUrl)
     {
         // URL format: https://sqs.{region}.amazonaws.com/{account-id}/{queue-name}
         var uri = new Uri(queueUrl);
         var hostParts = uri.Host.Split('.');
-        
+
         if (hostParts.Length >= 3 && hostParts[0] == "sqs")
         {
             return hostParts[1];

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Common/AmazonSQSClientFactory.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Common/AmazonSQSClientFactory.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace Azure.WebJobs.Extensions.SQS;
 
 using System;
@@ -7,12 +7,13 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.SQS;
 using Azure.WebJobs.Extensions.SQS.Auth;
+using Microsoft.Extensions.Logging;
 using AzureCore = global::Azure.Core;
 using AzureIdentity = global::Azure.Identity;
 
 public class AmazonSQSClientFactory
 {
-    public static AmazonSQSClient Build(SqsQueueTriggerAttribute triggerParameters)
+    public static AmazonSQSClient Build(SqsQueueTriggerAttribute triggerParameters, ILogger? logger = null)
     {
         return Build(
             queueUrl: triggerParameters.QueueUrl,
@@ -25,10 +26,11 @@ public class AmazonSQSClientFactory
             awsSessionDurationSeconds: triggerParameters.AwsSessionDurationSeconds,
             entraTenantId: triggerParameters.EntraTenantId,
             entraClientId: triggerParameters.EntraClientId,
-            entraClientSecret: triggerParameters.EntraClientSecret);
+            entraClientSecret: triggerParameters.EntraClientSecret,
+            logger: logger);
     }
 
-    public static AmazonSQSClient Build(SqsQueueOutAttribute outParameters)
+    public static AmazonSQSClient Build(SqsQueueOutAttribute outParameters, ILogger? logger = null)
     {
         return Build(
             queueUrl: outParameters.QueueUrl,
@@ -41,7 +43,8 @@ public class AmazonSQSClientFactory
             awsSessionDurationSeconds: outParameters.AwsSessionDurationSeconds,
             entraTenantId: outParameters.EntraTenantId,
             entraClientId: outParameters.EntraClientId,
-            entraClientSecret: outParameters.EntraClientSecret);
+            entraClientSecret: outParameters.EntraClientSecret,
+            logger: logger);
     }
 
     private static AmazonSQSClient Build(
@@ -55,59 +58,110 @@ public class AmazonSQSClientFactory
         int awsSessionDurationSeconds,
         string? entraTenantId,
         string? entraClientId,
-        string? entraClientSecret)
+        string? entraClientSecret,
+        ILogger? logger)
     {
-        // Extract region from queue URL
         var sqsRegion = ExtractRegionFromQueueUrl(queueUrl);
         var region = !string.IsNullOrEmpty(regionOverride)
             ? RegionEndpoint.GetBySystemName(regionOverride)
             : RegionEndpoint.EnumerableAllRegions.Single(r => r.SystemName.Equals(sqsRegion, StringComparison.OrdinalIgnoreCase));
 
+        var credentials = SelectCredentials(
+            awsKeyId: awsKeyId,
+            awsAccessKey: awsAccessKey,
+            awsRoleArn: awsRoleArn,
+            awsStsAudience: awsStsAudience,
+            awsRoleSessionName: awsRoleSessionName,
+            awsSessionDurationSeconds: awsSessionDurationSeconds,
+            stsRegion: region,
+            entraTenantId: entraTenantId,
+            entraClientId: entraClientId,
+            entraClientSecret: entraClientSecret,
+            logger: logger);
+
+        return credentials is null
+            ? new AmazonSQSClient(region)
+            : new AmazonSQSClient(credentials, region);
+    }
+
+    /// <summary>
+    /// Selects the AWS credentials source. Returns <c>null</c> when the caller should
+    /// fall back to the AWS SDK's default credential chain (env vars, shared file, etc.).
+    /// Priority: Entra federation (when <paramref name="awsRoleArn"/> is set) → explicit
+    /// access key + secret → default chain.
+    /// </summary>
+    internal static AWSCredentials? SelectCredentials(
+        string? awsKeyId,
+        string? awsAccessKey,
+        string? awsRoleArn,
+        string awsStsAudience,
+        string awsRoleSessionName,
+        int awsSessionDurationSeconds,
+        RegionEndpoint stsRegion,
+        string? entraTenantId,
+        string? entraClientId,
+        string? entraClientSecret,
+        ILogger? logger = null)
+    {
         // Entra ID federation takes precedence when a role ARN is provided.
         // No long-lived AWS secret is stored — an Entra token is exchanged for
         // temporary AWS credentials via STS AssumeRoleWithWebIdentity.
         if (!string.IsNullOrEmpty(awsRoleArn))
         {
             var entraCredential = BuildEntraCredential(entraTenantId, entraClientId, entraClientSecret);
-            var federatedCredentials = new EntraIdFederatedCredentials(
+            return new EntraIdFederatedCredentials(
                 roleArn: awsRoleArn!,
                 audience: awsStsAudience,
                 roleSessionName: awsRoleSessionName,
                 sessionDurationSeconds: awsSessionDurationSeconds,
-                stsRegion: region,
+                stsRegion: stsRegion,
+                logger: logger,
                 getEntraToken: entraCredential.GetTokenAsync);
-            return new AmazonSQSClient(federatedCredentials, region);
         }
 
-        // Use AWS credential chain if no explicit credentials provided
-        // This supports: Environment variables, ECS container credentials, EC2 instance profile, etc.
         if (string.IsNullOrEmpty(awsKeyId) || string.IsNullOrEmpty(awsAccessKey))
         {
-            return new AmazonSQSClient(region);
+            return null;
         }
 
-        // Fall back to explicit credentials if provided (for backward compatibility)
-        var credentials = new BasicAWSCredentials(accessKey: awsKeyId, secretKey: awsAccessKey);
-        return new AmazonSQSClient(credentials, region);
+        return new BasicAWSCredentials(accessKey: awsKeyId, secretKey: awsAccessKey);
     }
 
     /// <summary>
-    /// Selects the Entra credential used to obtain the federation token.
-    /// If all three app-registration fields are provided, uses ClientSecretCredential.
-    /// Otherwise falls back to DefaultAzureCredential, which picks up the Function App's
-    /// managed identity in production (the recommended, password-less option) and the
-    /// developer's Entra identity (e.g. via az login or Visual Studio) locally.
+    /// Selects the Entra credential used to obtain the federation token. All three
+    /// app-registration fields must be provided together or all omitted; partial
+    /// configuration throws rather than silently falling back to DefaultAzureCredential,
+    /// since that silent downgrade has bitten users who typo'd a Key Vault reference
+    /// ("works in dev via az login, fails in prod"). When all three are omitted, uses
+    /// DefaultAzureCredential — which picks up the Function App's managed identity
+    /// in production and the developer's Entra identity locally.
     /// </summary>
     internal static AzureCore.TokenCredential BuildEntraCredential(
         string? entraTenantId,
         string? entraClientId,
         string? entraClientSecret)
     {
-        if (!string.IsNullOrEmpty(entraTenantId)
-            && !string.IsNullOrEmpty(entraClientId)
-            && !string.IsNullOrEmpty(entraClientSecret))
+        var hasTenantId = !string.IsNullOrEmpty(entraTenantId);
+        var hasClientId = !string.IsNullOrEmpty(entraClientId);
+        var hasClientSecret = !string.IsNullOrEmpty(entraClientSecret);
+
+        if (hasTenantId && hasClientId && hasClientSecret)
         {
             return new AzureIdentity.ClientSecretCredential(entraTenantId, entraClientId, entraClientSecret);
+        }
+
+        if (hasTenantId || hasClientId || hasClientSecret)
+        {
+            var missing = string.Join(", ",
+                new[]
+                {
+                    hasTenantId ? null : nameof(SqsQueueTriggerAttribute.EntraTenantId),
+                    hasClientId ? null : nameof(SqsQueueTriggerAttribute.EntraClientId),
+                    hasClientSecret ? null : nameof(SqsQueueTriggerAttribute.EntraClientSecret),
+                }.Where(x => x is not null));
+            throw new InvalidOperationException(
+                $"Partial Entra app-registration configuration: missing {missing}. " +
+                "Provide all three (EntraTenantId, EntraClientId, EntraClientSecret) or omit all three to use managed identity.");
         }
 
         return new AzureIdentity.DefaultAzureCredential();

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueOutAttribute.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueOutAttribute.cs
@@ -31,4 +31,58 @@ public class SqsQueueOutAttribute : Attribute
     /// </summary>
     [AutoResolve]
     public string? Region { get; set; }
+
+    /// <summary>
+    /// AWS IAM Role ARN to assume via Entra ID OIDC federation. When set, the extension
+    /// authenticates by exchanging an Entra ID token (from the Function App's managed
+    /// identity, or DefaultAzureCredential locally) for temporary AWS credentials via
+    /// STS AssumeRoleWithWebIdentity — no AWS secret needs to be stored. Takes precedence
+    /// over AWSKeyId/AWSAccessKey and the AWS default credential chain.
+    /// </summary>
+    [AutoResolve]
+    public string? AwsRoleArn { get; set; }
+
+    /// <summary>
+    /// Entra ID token audience used when federating to AWS. Defaults to
+    /// "api://AWSSecurityTokenService". Must match the AWS IAM trust policy.
+    /// </summary>
+    [AutoResolve]
+    public string AwsStsAudience { get; set; } = "api://AWSSecurityTokenService";
+
+    /// <summary>
+    /// Session name passed to STS AssumeRoleWithWebIdentity. Surfaces in CloudTrail
+    /// for auditing. Defaults to "azure-functions-sqs".
+    /// </summary>
+    [AutoResolve]
+    public string AwsRoleSessionName { get; set; } = "azure-functions-sqs";
+
+    /// <summary>
+    /// Duration in seconds for the assumed-role session. Must be between 900 (15 min)
+    /// and the maximum configured on the IAM role (default 3600). Defaults to 3600.
+    /// </summary>
+    public int AwsSessionDurationSeconds { get; set; } = 3600;
+
+    /// <summary>
+    /// Entra ID (Azure AD) tenant ID for an app registration used to obtain the federated
+    /// token. Optional. When set together with EntraClientId and EntraClientSecret, the
+    /// extension uses ClientSecretCredential. If left unset, DefaultAzureCredential is used,
+    /// which picks up the Function App's managed identity in production — the recommended,
+    /// password-less option.
+    /// </summary>
+    [AutoResolve]
+    public string? EntraTenantId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client ID for an app registration. See <see cref="EntraTenantId"/>.
+    /// </summary>
+    [AutoResolve]
+    public string? EntraClientId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client secret for an app registration. Should be referenced from
+    /// Azure Key Vault rather than stored as a literal app setting. Prefer managed identity
+    /// (leave this unset) over an app registration with a secret.
+    /// </summary>
+    [AutoResolve]
+    public string? EntraClientSecret { get; set; }
 }

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueTriggerAttribute.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueTriggerAttribute.cs
@@ -31,4 +31,59 @@ public class SqsQueueTriggerAttribute : Attribute
     /// </summary>
     [AutoResolve]
     public string? Region { get; set; }
+
+    /// <summary>
+    /// AWS IAM Role ARN to assume via Entra ID OIDC federation. When set, the extension
+    /// authenticates by exchanging an Entra ID token (from the Function App's managed
+    /// identity, or DefaultAzureCredential locally) for temporary AWS credentials via
+    /// STS AssumeRoleWithWebIdentity — no AWS secret needs to be stored. Takes precedence
+    /// over AWSKeyId/AWSAccessKey and the AWS default credential chain.
+    /// </summary>
+    [AutoResolve]
+    public string? AwsRoleArn { get; set; }
+
+    /// <summary>
+    /// Entra ID token audience used when federating to AWS. Defaults to
+    /// "api://AWSSecurityTokenService" (the standard AWS-recommended audience).
+    /// Must match the audience configured in the AWS IAM trust policy.
+    /// </summary>
+    [AutoResolve]
+    public string AwsStsAudience { get; set; } = "api://AWSSecurityTokenService";
+
+    /// <summary>
+    /// Session name passed to STS AssumeRoleWithWebIdentity. Surfaces in CloudTrail
+    /// for auditing. Defaults to "azure-functions-sqs".
+    /// </summary>
+    [AutoResolve]
+    public string AwsRoleSessionName { get; set; } = "azure-functions-sqs";
+
+    /// <summary>
+    /// Duration in seconds for the assumed-role session. Must be between 900 (15 min)
+    /// and the maximum configured on the IAM role (default 3600). Defaults to 3600.
+    /// </summary>
+    public int AwsSessionDurationSeconds { get; set; } = 3600;
+
+    /// <summary>
+    /// Entra ID (Azure AD) tenant ID for an app registration used to obtain the federated
+    /// token. Optional. When set together with EntraClientId and EntraClientSecret, the
+    /// extension uses ClientSecretCredential. If left unset, DefaultAzureCredential is used,
+    /// which picks up the Function App's managed identity in production — the recommended,
+    /// password-less option.
+    /// </summary>
+    [AutoResolve]
+    public string? EntraTenantId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client ID for an app registration. See <see cref="EntraTenantId"/>.
+    /// </summary>
+    [AutoResolve]
+    public string? EntraClientId { get; set; }
+
+    /// <summary>
+    /// Entra ID (Azure AD) client secret for an app registration. Should be referenced from
+    /// Azure Key Vault rather than stored as a literal app setting. Prefer managed identity
+    /// (leave this unset) over an app registration with a secret.
+    /// </summary>
+    [AutoResolve]
+    public string? EntraClientSecret { get; set; }
 }

--- a/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueTriggerListener.cs
+++ b/dotnet/src/Azure.WebJobs.Extensions.SQS/Trigger/SqsQueueTriggerListener.cs
@@ -41,7 +41,7 @@ public class SqsQueueTriggerListener : IListener
         _sqsQueueOptions.Value.PollingInterval ??= TimeSpan.FromSeconds(5);
         _sqsQueueOptions.Value.VisibilityTimeout ??= TimeSpan.FromSeconds(30);
 
-        _amazonSqsClient = AmazonSQSClientFactory.Build(triggerParameters);
+        _amazonSqsClient = AmazonSQSClientFactory.Build(triggerParameters, _logger);
     }
 
     public void Cancel()

--- a/dotnet/test/Extensions.SQS.UnitTests/AmazonSQSClientFactoryTests.cs
+++ b/dotnet/test/Extensions.SQS.UnitTests/AmazonSQSClientFactoryTests.cs
@@ -1,7 +1,10 @@
 namespace Extensions.SQS.UnitTests;
 
 using System;
+using Amazon;
+using Amazon.Runtime;
 using Azure.WebJobs.Extensions.SQS;
+using Azure.WebJobs.Extensions.SQS.Auth;
 using FluentAssertions;
 using Xunit;
 
@@ -236,24 +239,60 @@ public class AmazonSQSClientFactoryTests
     }
 
     [Fact]
-    public void Build_WithAwsRoleArn_TakesPrecedenceOverExplicitKeys()
+    public void SelectCredentials_WithRoleArnAndExplicitKeys_PrefersFederation()
     {
-        // Both federation config and explicit keys provided; federation should win.
-        // We can't directly inspect the credentials provider attached to the client
-        // without internal SDK access, but at minimum the call must succeed without
-        // touching either credential source (no STS call happens until the client
-        // first sends a request).
-        var attribute = new SqsQueueTriggerAttribute
-        {
-            QueueUrl = ValidQueueUrl,
-            AWSKeyId = "AKIAIOSFODNN7EXAMPLE",
-            AWSAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-            AwsRoleArn = "arn:aws:iam::123456789012:role/my-role",
-        };
+        // Federation must win over explicit keys. The SelectCredentials seam lets us
+        // assert the chosen credentials type directly instead of relying on "the call
+        // didn't throw" as a proxy for precedence.
+        var credentials = AmazonSQSClientFactory.SelectCredentials(
+            awsKeyId: "AKIAIOSFODNN7EXAMPLE",
+            awsAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            awsRoleArn: "arn:aws:iam::123456789012:role/my-role",
+            awsStsAudience: "api://AWSSecurityTokenService",
+            awsRoleSessionName: "azure-functions-sqs",
+            awsSessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            entraTenantId: null,
+            entraClientId: null,
+            entraClientSecret: null);
 
-        using var client = AmazonSQSClientFactory.Build(attribute);
+        credentials.Should().BeOfType<EntraIdFederatedCredentials>();
+    }
 
-        client.Should().NotBeNull();
+    [Fact]
+    public void SelectCredentials_WithExplicitKeysOnly_ReturnsBasicCredentials()
+    {
+        var credentials = AmazonSQSClientFactory.SelectCredentials(
+            awsKeyId: "AKIAIOSFODNN7EXAMPLE",
+            awsAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            awsRoleArn: null,
+            awsStsAudience: "api://AWSSecurityTokenService",
+            awsRoleSessionName: "azure-functions-sqs",
+            awsSessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            entraTenantId: null,
+            entraClientId: null,
+            entraClientSecret: null);
+
+        credentials.Should().BeOfType<BasicAWSCredentials>();
+    }
+
+    [Fact]
+    public void SelectCredentials_WithNoCredentials_ReturnsNullForDefaultChain()
+    {
+        var credentials = AmazonSQSClientFactory.SelectCredentials(
+            awsKeyId: null,
+            awsAccessKey: null,
+            awsRoleArn: null,
+            awsStsAudience: "api://AWSSecurityTokenService",
+            awsRoleSessionName: "azure-functions-sqs",
+            awsSessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            entraTenantId: null,
+            entraClientId: null,
+            entraClientSecret: null);
+
+        credentials.Should().BeNull();
     }
 
     [Fact]
@@ -308,20 +347,22 @@ public class AmazonSQSClientFactoryTests
     }
 
     [Theory]
-    [InlineData(null, "client-id", "secret")]
-    [InlineData("tenant-id", null, "secret")]
-    [InlineData("tenant-id", "client-id", null)]
-    [InlineData("", "client-id", "secret")]
-    [InlineData("tenant-id", "", "secret")]
-    [InlineData("tenant-id", "client-id", "")]
-    public void BuildEntraCredential_WithPartialAppRegFields_ReturnsDefaultAzureCredential(
-        string? tenantId, string? clientId, string? clientSecret)
+    [InlineData(null, "client-id", "secret", "EntraTenantId")]
+    [InlineData("tenant-id", null, "secret", "EntraClientId")]
+    [InlineData("tenant-id", "client-id", null, "EntraClientSecret")]
+    [InlineData("", "client-id", "secret", "EntraTenantId")]
+    [InlineData("tenant-id", "", "secret", "EntraClientId")]
+    [InlineData("tenant-id", "client-id", "", "EntraClientSecret")]
+    public void BuildEntraCredential_WithPartialAppRegFields_Throws(
+        string? tenantId, string? clientId, string? clientSecret, string missingField)
     {
-        // Partial app-reg config falls back to DefaultAzureCredential rather than failing —
-        // this lets users override one field via env var without redeclaring all three.
-        var credential = AmazonSQSClientFactory.BuildEntraCredential(tenantId, clientId, clientSecret);
+        // Partial app-reg configuration is a misconfiguration, not a fallback path.
+        // Silently downgrading to DefaultAzureCredential masks typo'd Key Vault references —
+        // works in dev via az login, fails opaquely in prod. Fail loud at startup instead.
+        var act = () => AmazonSQSClientFactory.BuildEntraCredential(tenantId, clientId, clientSecret);
 
-        credential.Should().BeOfType<global::Azure.Identity.DefaultAzureCredential>();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{missingField}*");
     }
 
     [Fact]

--- a/dotnet/test/Extensions.SQS.UnitTests/AmazonSQSClientFactoryTests.cs
+++ b/dotnet/test/Extensions.SQS.UnitTests/AmazonSQSClientFactoryTests.cs
@@ -218,6 +218,131 @@ public class AmazonSQSClientFactoryTests
 
     #endregion
 
+    #region Entra ID Federation Tests
+
+    [Fact]
+    public void Build_WithAwsRoleArn_CreatesClient()
+    {
+        var attribute = new SqsQueueTriggerAttribute
+        {
+            QueueUrl = ValidQueueUrl,
+            AwsRoleArn = "arn:aws:iam::123456789012:role/my-role",
+        };
+
+        using var client = AmazonSQSClientFactory.Build(attribute);
+
+        client.Should().NotBeNull();
+        client.Config.RegionEndpoint.SystemName.Should().Be("us-east-1");
+    }
+
+    [Fact]
+    public void Build_WithAwsRoleArn_TakesPrecedenceOverExplicitKeys()
+    {
+        // Both federation config and explicit keys provided; federation should win.
+        // We can't directly inspect the credentials provider attached to the client
+        // without internal SDK access, but at minimum the call must succeed without
+        // touching either credential source (no STS call happens until the client
+        // first sends a request).
+        var attribute = new SqsQueueTriggerAttribute
+        {
+            QueueUrl = ValidQueueUrl,
+            AWSKeyId = "AKIAIOSFODNN7EXAMPLE",
+            AWSAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            AwsRoleArn = "arn:aws:iam::123456789012:role/my-role",
+        };
+
+        using var client = AmazonSQSClientFactory.Build(attribute);
+
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Build_WithAwsRoleArn_OnOutAttribute_CreatesClient()
+    {
+        var attribute = new SqsQueueOutAttribute
+        {
+            QueueUrl = ValidQueueUrl,
+            AwsRoleArn = "arn:aws:iam::123456789012:role/my-role",
+        };
+
+        using var client = AmazonSQSClientFactory.Build(attribute);
+
+        client.Should().NotBeNull();
+        client.Config.RegionEndpoint.SystemName.Should().Be("us-east-1");
+    }
+
+    [Fact]
+    public void Build_WithEmptyAwsRoleArn_FallsBackToCredentialChain()
+    {
+        var attribute = new SqsQueueTriggerAttribute
+        {
+            QueueUrl = ValidQueueUrl,
+            AwsRoleArn = "",
+        };
+
+        using var client = AmazonSQSClientFactory.Build(attribute);
+
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void BuildEntraCredential_WithAllAppRegFields_ReturnsClientSecretCredential()
+    {
+        var credential = AmazonSQSClientFactory.BuildEntraCredential(
+            entraTenantId: "11111111-1111-1111-1111-111111111111",
+            entraClientId: "22222222-2222-2222-2222-222222222222",
+            entraClientSecret: "fake-secret-value");
+
+        credential.Should().BeOfType<global::Azure.Identity.ClientSecretCredential>();
+    }
+
+    [Fact]
+    public void BuildEntraCredential_WithNoAppRegFields_ReturnsDefaultAzureCredential()
+    {
+        var credential = AmazonSQSClientFactory.BuildEntraCredential(
+            entraTenantId: null,
+            entraClientId: null,
+            entraClientSecret: null);
+
+        credential.Should().BeOfType<global::Azure.Identity.DefaultAzureCredential>();
+    }
+
+    [Theory]
+    [InlineData(null, "client-id", "secret")]
+    [InlineData("tenant-id", null, "secret")]
+    [InlineData("tenant-id", "client-id", null)]
+    [InlineData("", "client-id", "secret")]
+    [InlineData("tenant-id", "", "secret")]
+    [InlineData("tenant-id", "client-id", "")]
+    public void BuildEntraCredential_WithPartialAppRegFields_ReturnsDefaultAzureCredential(
+        string? tenantId, string? clientId, string? clientSecret)
+    {
+        // Partial app-reg config falls back to DefaultAzureCredential rather than failing —
+        // this lets users override one field via env var without redeclaring all three.
+        var credential = AmazonSQSClientFactory.BuildEntraCredential(tenantId, clientId, clientSecret);
+
+        credential.Should().BeOfType<global::Azure.Identity.DefaultAzureCredential>();
+    }
+
+    [Fact]
+    public void Build_WithAwsRoleArn_AndAppRegFields_CreatesClient()
+    {
+        var attribute = new SqsQueueTriggerAttribute
+        {
+            QueueUrl = ValidQueueUrl,
+            AwsRoleArn = "arn:aws:iam::123456789012:role/my-role",
+            EntraTenantId = "11111111-1111-1111-1111-111111111111",
+            EntraClientId = "22222222-2222-2222-2222-222222222222",
+            EntraClientSecret = "fake-secret-value",
+        };
+
+        using var client = AmazonSQSClientFactory.Build(attribute);
+
+        client.Should().NotBeNull();
+    }
+
+    #endregion
+
     #region SqsQueueOutAttribute Tests
 
     [Fact]

--- a/dotnet/test/Extensions.SQS.UnitTests/EntraIdFederatedCredentialsTests.cs
+++ b/dotnet/test/Extensions.SQS.UnitTests/EntraIdFederatedCredentialsTests.cs
@@ -1,6 +1,7 @@
 namespace Extensions.SQS.UnitTests;
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;
@@ -8,6 +9,7 @@ using Amazon.SecurityToken.Model;
 using Azure.Core;
 using Azure.WebJobs.Extensions.SQS.Auth;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 public class EntraIdFederatedCredentialsTests
@@ -172,5 +174,106 @@ public class EntraIdFederatedCredentialsTests
             sessionDurationSeconds: 3600,
             stsRegion: null!);
         act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(899)]
+    public void Constructor_SessionDurationBelowMinimum_Throws(int durationSeconds)
+    {
+        // STS rejects assume-role sessions shorter than 900s. Surface the error at
+        // startup rather than at first SQS call.
+        var act = () => new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "s",
+            sessionDurationSeconds: durationSeconds,
+            stsRegion: RegionEndpoint.USEast1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void GetCredentials_LogsDebugOnRefresh()
+    {
+        var logger = new RecordingLogger();
+        var entraToken = new AccessToken("t", DateTimeOffset.UtcNow.AddMinutes(60));
+
+        var creds = new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "s",
+            sessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            logger: logger,
+            getEntraToken: (_, _) => new ValueTask<AccessToken>(entraToken),
+            assumeRoleAsync: (_, _) => Task.FromResult(MakeStsResponse()));
+
+        creds.GetCredentials();
+
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Debug);
+    }
+
+    [Fact]
+    public void GetCredentials_LogsWarningWhenEntraTokenFails()
+    {
+        var logger = new RecordingLogger();
+
+        var creds = new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "s",
+            sessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            logger: logger,
+            getEntraToken: (_, _) => throw new InvalidOperationException("entra boom"),
+            assumeRoleAsync: (_, _) => Task.FromResult(MakeStsResponse()));
+
+        var act = () => creds.GetCredentials();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*entra boom*");
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Exception is InvalidOperationException);
+    }
+
+    [Fact]
+    public void GetCredentials_LogsWarningWhenStsFails()
+    {
+        var logger = new RecordingLogger();
+        var entraToken = new AccessToken("t", DateTimeOffset.UtcNow.AddMinutes(60));
+
+        var creds = new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "s",
+            sessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            logger: logger,
+            getEntraToken: (_, _) => new ValueTask<AccessToken>(entraToken),
+            assumeRoleAsync: (_, _) => throw new InvalidOperationException("sts boom"));
+
+        var act = () => creds.GetCredentials();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*sts boom*");
+        logger.Entries.Should().Contain(e => e.Level == LogLevel.Warning && e.Exception is InvalidOperationException);
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(LogLevel Level, Exception? Exception, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, exception, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/dotnet/test/Extensions.SQS.UnitTests/EntraIdFederatedCredentialsTests.cs
+++ b/dotnet/test/Extensions.SQS.UnitTests/EntraIdFederatedCredentialsTests.cs
@@ -1,0 +1,176 @@
+namespace Extensions.SQS.UnitTests;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.SecurityToken.Model;
+using Azure.Core;
+using Azure.WebJobs.Extensions.SQS.Auth;
+using FluentAssertions;
+using Xunit;
+
+public class EntraIdFederatedCredentialsTests
+{
+    private static AssumeRoleWithWebIdentityResponse MakeStsResponse(
+        string accessKey = "ASIA-fake",
+        string secret = "secret-fake",
+        string session = "session-fake",
+        int expiresInMinutes = 50)
+    {
+        return new AssumeRoleWithWebIdentityResponse
+        {
+            Credentials = new Credentials
+            {
+                AccessKeyId = accessKey,
+                SecretAccessKey = secret,
+                SessionToken = session,
+                Expiration = DateTime.UtcNow.AddMinutes(expiresInMinutes),
+            },
+        };
+    }
+
+    [Fact]
+    public void GetCredentials_ReturnsCredentialsFromStsResponse()
+    {
+        var entraToken = new AccessToken("fake-entra-token", DateTimeOffset.UtcNow.AddMinutes(60));
+        var stsResponse = MakeStsResponse();
+
+        var creds = new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/test-role",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "azure-functions-sqs",
+            sessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            getEntraToken: (_, _) => new ValueTask<AccessToken>(entraToken),
+            assumeRoleAsync: (_, _) => Task.FromResult(stsResponse));
+
+        var immutable = creds.GetCredentials();
+
+        immutable.AccessKey.Should().Be("ASIA-fake");
+        immutable.SecretKey.Should().Be("secret-fake");
+        immutable.Token.Should().Be("session-fake");
+    }
+
+    [Fact]
+    public void GetCredentials_PassesEntraTokenAndConfigToStsRequest()
+    {
+        var entraToken = new AccessToken("fake-entra-token", DateTimeOffset.UtcNow.AddMinutes(60));
+        AssumeRoleWithWebIdentityRequest? captured = null;
+
+        var creds = new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/my-role",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "my-session",
+            sessionDurationSeconds: 1800,
+            stsRegion: RegionEndpoint.USEast1,
+            getEntraToken: (_, _) => new ValueTask<AccessToken>(entraToken),
+            assumeRoleAsync: (req, _) =>
+            {
+                captured = req;
+                return Task.FromResult(MakeStsResponse());
+            });
+
+        creds.GetCredentials();
+
+        captured.Should().NotBeNull();
+        captured!.RoleArn.Should().Be("arn:aws:iam::123456789012:role/my-role");
+        captured.RoleSessionName.Should().Be("my-session");
+        captured.WebIdentityToken.Should().Be("fake-entra-token");
+        captured.DurationSeconds.Should().Be(1800);
+    }
+
+    [Fact]
+    public void GetCredentials_PassesAudienceWithDotDefaultScopeToTokenProvider()
+    {
+        TokenRequestContext? capturedContext = null;
+        var entraToken = new AccessToken("t", DateTimeOffset.UtcNow.AddMinutes(60));
+
+        var creds = new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: "api://CustomAudience",
+            roleSessionName: "s",
+            sessionDurationSeconds: 900,
+            stsRegion: RegionEndpoint.USEast1,
+            getEntraToken: (ctx, _) =>
+            {
+                capturedContext = ctx;
+                return new ValueTask<AccessToken>(entraToken);
+            },
+            assumeRoleAsync: (_, _) => Task.FromResult(MakeStsResponse()));
+
+        creds.GetCredentials();
+
+        capturedContext.Should().NotBeNull();
+        capturedContext!.Value.Scopes.Should().ContainSingle()
+            .Which.Should().Be("api://CustomAudience/.default");
+    }
+
+    [Fact]
+    public void GetCredentials_CachesCredentialsAndDoesNotRefetchWithinExpiry()
+    {
+        var entraToken = new AccessToken("t", DateTimeOffset.UtcNow.AddMinutes(60));
+        var tokenCalls = 0;
+        var stsCalls = 0;
+
+        var creds = new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "s",
+            sessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1,
+            getEntraToken: (_, _) =>
+            {
+                Interlocked.Increment(ref tokenCalls);
+                return new ValueTask<AccessToken>(entraToken);
+            },
+            assumeRoleAsync: (_, _) =>
+            {
+                Interlocked.Increment(ref stsCalls);
+                return Task.FromResult(MakeStsResponse(expiresInMinutes: 50));
+            });
+
+        creds.GetCredentials();
+        creds.GetCredentials();
+        creds.GetCredentials();
+
+        tokenCalls.Should().Be(1);
+        stsCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public void Constructor_NullRoleArn_Throws()
+    {
+        var act = () => new EntraIdFederatedCredentials(
+            roleArn: null!,
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "s",
+            sessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_NullAudience_Throws()
+    {
+        var act = () => new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: null!,
+            roleSessionName: "s",
+            sessionDurationSeconds: 3600,
+            stsRegion: RegionEndpoint.USEast1);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_NullStsRegion_Throws()
+    {
+        var act = () => new EntraIdFederatedCredentials(
+            roleArn: "arn:aws:iam::123456789012:role/r",
+            audience: "api://AWSSecurityTokenService",
+            roleSessionName: "s",
+            sessionDurationSeconds: 3600,
+            stsRegion: null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #84. Adds password-less AWS auth via Azure Managed Identity → Entra ID → AWS STS `AssumeRoleWithWebIdentity`, so the SQS trigger/output bindings no longer require a long-lived AWS access key in Azure config.
- Also supports an Entra app-registration + client-secret variant for environments without managed identity (still removes the AWS secret; only an Entra secret remains).
- Fully backwards compatible for in-scope auth paths — the existing AWS access-key and credential-chain paths are unchanged. Federation activates only when `AwsRoleArn` is set on the binding attribute.
- New `docs/AUTHENTICATION.md` documents all three auth patterns side-by-side and recommends managed-identity federation as the default.

## What's in scope

- New `EntraIdFederatedCredentials` (`RefreshingAWSCredentials` subclass) that exchanges an Entra token for STS creds and auto-refreshes. Validates the STS minimum session duration (900s) at construction. Accepts an optional `ILogger` for refresh/failure logging.
- `AmazonSQSClientFactory` selects credentials in priority order: **federation → explicit access keys → AWS credential chain**. Federation wins whenever `AwsRoleArn` is set; explicit keys are used only when both `AWSKeyId` and `AWSAccessKey` are set; otherwise the AWS default credential chain.
- New attribute properties on all four trigger/output attributes (host + worker): `AwsRoleArn`, `AwsStsAudience`, `AwsRoleSessionName`, `AwsSessionDurationSeconds`, `EntraTenantId`, `EntraClientId`, `EntraClientSecret`
- New host-side deps: `Azure.Identity 1.13.1`, `AWSSDK.SecurityToken 3.7.300.55`
- Unit tests for the new credentials class (mocked token + STS callbacks, logging, bounds check) and for the factory's credential-selection branches (real precedence assertion via the internal `SelectCredentials` seam)

## Behavior change to be aware of

**Partial Entra app-registration configuration now fails loud at startup** rather than silently falling back to `DefaultAzureCredential`. Previously, setting e.g. `EntraTenantId` + `EntraClientId` without `EntraClientSecret` would transparently use managed identity — which masks typo'd Key Vault references (works in dev via `az login`, fails opaquely in prod). All three Entra fields must now be provided together, or all omitted. Omitting all three still uses `DefaultAzureCredential` as before.

## What's intentionally not in scope

- **Version bump / CHANGELOG**: deferred so release timing stays a separate decision.
- **AWS SDK upgrade** (#50): kept on its own branch to keep this diff reviewable.
- **STS endpoint override** (needed for LocalStack Pro): follow-up; `AmazonSecurityTokenServiceClient` is constructed with the SQS queue's region today.
- **Logger plumbing on the output-binding path**: the trigger listener now passes its `ILogger` through to the factory, but `SqsQueueAsyncCollector` has no logger in its ctor — threading one in is a separate refactor.
- **Pre-existing test failures in `SqsQueueTriggerAttributeTests`** for #42 (`QueueUrl` validation that doesn't exist) — these fail on `main` too and are out of scope here.

## Test plan

- [x] `dotnet test` — 145/150 passing locally; 4 failures are pre-existing #42 aspirational tests unrelated to this change (1 skipped)
- [x] All 49 federation + factory tests pass, including the new real precedence test, partial-app-reg throws, session-duration bounds, and logger behavior
- [ ] Manual end-to-end against a real Azure Function with managed identity → AWS IAM role
- [ ] Manual end-to-end with an Entra app registration + Key Vault-backed client secret
- [ ] Verify the existing access-key auth path still works on the test app (regression check)